### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "osvr/RenderKit/NDA/OSVR-RenderManager-AMD"]
 	path = osvr/RenderKit/NDA/OSVR-RenderManager-AMD
-	url = git@github.com:sensics/OSVR-RenderManager-AMD.git
+	url = https://github.com/sensics/OSVR-RenderManager-AMD.git
 [submodule "osvr/RenderKit/NDA/OSVR-RenderManager-NVIDIA"]
 	path = osvr/RenderKit/NDA/OSVR-RenderManager-NVIDIA
-	url = git@github.com:sensics/OSVR-RenderManager-NVIDIA.git
+	url = https://github.com/sensics/OSVR-RenderManager-NVIDIA.git


### PR DESCRIPTION
Switch to https for default submodule transports.

Works better for CI and for a lot of people, and can be manually overridden locally by editing your local remotes.