### PR TITLE
RenderManager: Add forward declaration of the ClientContext class.

### DIFF
--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -34,7 +34,6 @@ Russ Taylor working through ReliaSolve.com for Sensics, Inc.
 #include <osvr/ClientKit/ContextC.h>
 #include <osvr/ClientKit/InterfaceC.h>
 #include <osvr/Util/TimeValueC.h>
-#include <osvr/ClientKit/Context.h>
 
 // Standard includes
 #include <vector>
@@ -42,6 +41,13 @@ Russ Taylor working through ReliaSolve.com for Sensics, Inc.
 #include <memory>
 #include <mutex>
 #include <array>
+
+// Forward declare the ClientContext class, so we don't depend on the OSVR C++ API.
+namespace osvr {
+namespace clientkit {
+    class ClientContext;
+} // namespace clientkit
+} // namespace osvr
 
 namespace osvr {
 namespace renderkit {

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -56,6 +56,7 @@ Russ Taylor working through ReliaSolve.com for Sensics, Inc.
 #include <osvr/Client/RenderManagerConfig.h>
 #include <osvr/ClientKit/TransformsC.h>
 #include <osvr/Common/IntegerByteSwap.h>
+#include <osvr/ClientKit/Context.h>
 
 // Library/third-party includes
 #include <Eigen/Core>


### PR DESCRIPTION
This way the RenderManager header only depends on the C API headers, which removes the dependency on C++ exception handling from the include headers.