### PR TITLE
Switched from using a C++ object to talk to the OSVR Client to using …

### DIFF
--- a/examples/RenderManagerOpenGLCoreExample.cpp
+++ b/examples/RenderManagerOpenGLCoreExample.cpp
@@ -25,6 +25,7 @@
 
 // Internal Includes
 #include <osvr/RenderKit/RenderManager.h>
+#include <osvr/ClientKit/Context.h>
 
 // Library/third-party includes
 #ifdef _WIN32

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -34,7 +34,6 @@ Russ Taylor working through ReliaSolve.com for Sensics, Inc.
 #include <osvr/ClientKit/ContextC.h>
 #include <osvr/ClientKit/InterfaceC.h>
 #include <osvr/Util/TimeValueC.h>
-#include <osvr/ClientKit/Context.h>
 
 // Standard includes
 #include <vector>
@@ -780,7 +779,7 @@ namespace renderkit {
 
       protected:
         /// @brief Constructor given OSVR context and parameters
-        RenderManager(std::shared_ptr<osvr::clientkit::ClientContext> context,
+        RenderManager(OSVR_ClientContext context,
                       const ConstructorParameters& p);
 
         /// Mutex to provide thread safety to this class and its
@@ -818,7 +817,7 @@ namespace renderkit {
             m_latchedRenderInfo; //< Stores vector of latched RenderInfo
 
         /// OSVR context to use.
-        std::shared_ptr<osvr::clientkit::ClientContext> m_context;
+        OSVR_ClientContext m_context;
 
         // Variables describing the desired characteristics of the
         // rendering, parsed from the display configuration file

--- a/osvr/RenderKit/RenderManagerD3D.cpp
+++ b/osvr/RenderKit/RenderManagerD3D.cpp
@@ -34,7 +34,7 @@ namespace osvr {
 namespace renderkit {
 
     RenderManagerD3D11::RenderManagerD3D11(
-        std::shared_ptr<osvr::clientkit::ClientContext> context,
+        OSVR_ClientContext context,
         ConstructorParameters p)
         : RenderManagerD3D11Base(context, p) {}
 

--- a/osvr/RenderKit/RenderManagerD3D.h
+++ b/osvr/RenderKit/RenderManagerD3D.h
@@ -40,7 +40,7 @@ namespace renderkit {
       protected:
         /// Construct a D3D RenderManager.
         RenderManagerD3D11(
-            std::shared_ptr<osvr::clientkit::ClientContext> context,
+            OSVR_ClientContext context,
             ConstructorParameters p);
 
         // Classes and structures needed to do our rendering.

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -80,7 +80,7 @@ namespace osvr {
             * and deletes it when the wrapper is deleted.
             */
             RenderManagerD3D11ATW(
-                std::shared_ptr<osvr::clientkit::ClientContext> context,
+                OSVR_ClientContext context,
                 ConstructorParameters p, RenderManagerD3D11Base* D3DToHarness)
                 : RenderManagerD3D11Base(context, p) {
                 mRTGraphicsLibrary = p.m_graphicsLibrary.D3D11;
@@ -215,7 +215,7 @@ namespace osvr {
             // * and deletes it when the wrapper is deleted.
             // */
             //RenderManagerD3D11ATW(
-            //    std::shared_ptr<osvr::clientkit::ClientContext> context,
+            //    OSVR_ClientContext context,
             //    ConstructorParameters p, std::unique_ptr<RenderManagerD3D11Base> && D3DToHarness)
             //    : RenderManager(context, p) {
             //    mRTGraphicsLibrary = p.m_graphicsLibrary.D3D11;
@@ -285,7 +285,7 @@ namespace osvr {
                             // Update the context so we get our callbacks called and
                             // update tracker state, which will be read during the
                             // time-warp calculation in our harnessed RenderManager.
-                            mRenderManager->m_context->update();
+                            osvrClientUpdate(mRenderManager->m_context);
 
                             {
                                 // make a new RenderBuffers array with the atw thread's buffers

--- a/osvr/RenderKit/RenderManagerD3DBase.cpp
+++ b/osvr/RenderKit/RenderManagerD3DBase.cpp
@@ -133,7 +133,7 @@ namespace osvr {
 namespace renderkit {
 
     RenderManagerD3D11Base::RenderManagerD3D11Base(
-        std::shared_ptr<osvr::clientkit::ClientContext> context,
+        OSVR_ClientContext context,
         ConstructorParameters p)
         : RenderManager(context, p) {
         // Initialize all of the variables that don't have to be done in the

--- a/osvr/RenderKit/RenderManagerD3DBase.h
+++ b/osvr/RenderKit/RenderManagerD3DBase.h
@@ -54,7 +54,7 @@ namespace renderkit {
       protected:
         /// Construct a D3D RenderManager.
         RenderManagerD3D11Base(
-            std::shared_ptr<osvr::clientkit::ClientContext> context,
+            OSVR_ClientContext context,
             ConstructorParameters p);
 
         virtual bool UpdateDistortionMeshesInternal(

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
@@ -35,7 +35,7 @@ namespace osvr {
 namespace renderkit {
 
     RenderManagerD3D11OpenGL::RenderManagerD3D11OpenGL(
-        std::shared_ptr<osvr::clientkit::ClientContext> context,
+        OSVR_ClientContext context,
         ConstructorParameters p,
         std::unique_ptr<RenderManagerD3D11Base>&& D3DToHarness)
         : RenderManagerOpenGL(context, p),

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.h
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.h
@@ -65,7 +65,7 @@ namespace renderkit {
         // NOTE: This will call delete on the harnessed RenderManager
         // when it is destroyed.
         RenderManagerD3D11OpenGL(
-            std::shared_ptr<osvr::clientkit::ClientContext> context,
+            OSVR_ClientContext context,
             ConstructorParameters p,
             std::unique_ptr<RenderManagerD3D11Base>&& D3DToHarness);
 

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -136,7 +136,7 @@ namespace renderkit {
     }
 
     RenderManagerOpenGL::RenderManagerOpenGL(
-        std::shared_ptr<osvr::clientkit::ClientContext> context,
+        OSVR_ClientContext context,
         ConstructorParameters p)
         : RenderManager(context, p) {
         // Initialize all of the variables that don't have to be done in the

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -70,7 +70,7 @@ namespace renderkit {
       protected:
         /// Construct an OpenGL render manager.
         RenderManagerOpenGL(
-            std::shared_ptr<osvr::clientkit::ClientContext> context,
+            OSVR_ClientContext context,
             ConstructorParameters p);
 
         OSVR_RENDERMANAGER_EXPORT bool UpdateDistortionMeshesInternal(


### PR DESCRIPTION
…the C API for internal RenderManager use.

This removes the dependence on any of the C++ OSVR include files and should also help avoid cross-DLL-boundary issues.