### PR TITLE
examples: Target the C++11 compiler for all executables.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,31 +15,38 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 	# impact of various latency-hiding techniques.
 	add_executable(AdjustableRenderingDelayD3D AdjustableRenderingDelayD3D.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(AdjustableRenderingDelayD3D PRIVATE osvrRM::osvrRenderManagerCpp)
+    target_compile_features(AdjustableRenderingDelayD3D PRIVATE cxx_range_for)
 
 	# D3D Example program
 	add_executable(RenderManagerD3DExample3D RenderManagerD3DExample3D.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DExample3D PRIVATE osvrRM::osvrRenderManagerCpp)
+    target_compile_features(RenderManagerD3DExample3D PRIVATE cxx_range_for)
 
 	# D3D Example program using Present mode
 	add_executable(RenderManagerD3DPresentExample3D RenderManagerD3DPresentExample3D.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DPresentExample3D PRIVATE osvrRM::osvrRenderManagerCpp)
+    target_compile_features(RenderManagerD3DPresentExample3D PRIVATE cxx_range_for)
 
 	# D3D Example program using Present mode that also passes in device and context
 	add_executable(RenderManagerD3DPresentMakeDeviceExample3D RenderManagerD3DPresentMakeDeviceExample3D.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DPresentMakeDeviceExample3D PRIVATE osvrRM::osvrRenderManagerCpp D3D11)
+    target_compile_features(RenderManagerD3DPresentMakeDeviceExample3D PRIVATE cxx_range_for)
 
 	# D3D Example program using Present mode that also passes in device and context and works with ATW
 	add_executable(RenderManagerD3DATWDoubleBufferExample RenderManagerD3DATWDoubleBufferExample.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DATWDoubleBufferExample PRIVATE osvrRM::osvrRenderManagerCpp D3D11)
+    target_compile_features(RenderManagerD3DATWDoubleBufferExample PRIVATE cxx_range_for)
 
 	# D3D Example program using Present mode
 	add_executable(RenderManagerD3DPresentSideBySideExample RenderManagerD3DPresentSideBySideExample.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DPresentSideBySideExample PRIVATE osvrRM::osvrRenderManagerCpp)
+    target_compile_features(RenderManagerD3DPresentSideBySideExample PRIVATE cxx_range_for)
 
 	#-----------------------------------------------------------------------------
 	# D3D Test program (basic 2D test)
 	add_executable(RenderManagerD3DTest2D RenderManagerD3DTest2D.cpp ${COMMON_D3D_2D_SOURCES})
 	target_link_libraries(RenderManagerD3DTest2D PRIVATE osvrRM::osvrRenderManagerCpp)
+    target_compile_features(RenderManagerD3DTest2D PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
@@ -58,10 +65,12 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 	# Latency test program
 	add_executable(LatencyTestD3DExample LatencyTestD3DExample.cpp ${COMMON_D3D_2D_SOURCES})
 	target_link_libraries(LatencyTestD3DExample PRIVATE osvrRM::osvrRenderManagerCpp vendored-quat)
+    target_compile_features(LatencyTestD3DExample PRIVATE cxx_range_for)
 
 	# D3D Example program
 	add_executable(RenderManagerD3DHeadSpaceExample RenderManagerD3DHeadSpaceExample.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(RenderManagerD3DHeadSpaceExample PRIVATE osvrRM::osvrRenderManagerCpp vendored-quat)
+    target_compile_features(RenderManagerD3DHeadSpaceExample PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
@@ -77,6 +86,7 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 	# steadiness of the rendering in the absence of motion.
 	add_executable(SpinCubeD3D SpinCubeD3D.cpp ${COMMON_D3D_SOURCES})
 	target_link_libraries(SpinCubeD3D PRIVATE osvrRM::osvrRenderManagerCpp vendored-vrpn vendored-quat)
+    target_compile_features(SpinCubeD3D PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
@@ -96,11 +106,13 @@ if(OSVRRM_HAVE_OPENGL_SUPPORT AND OPENGL_FOUND)
 	# OpenGL Example program
 	add_executable(RenderManagerOpenGLExample RenderManagerOpenGLExample.cpp)
 	target_link_libraries(RenderManagerOpenGLExample PRIVATE osvrRM::osvrRenderManagerCpp convenience_gldeps)
+    target_compile_features(RenderManagerOpenGLExample PRIVATE cxx_range_for)
 
 	#-----------------------------------------------------------------------------
 	# OpenGL Example program
 	add_executable(RenderManagerOpenGLHeadSpaceExample RenderManagerOpenGLHeadSpaceExample.cpp)
 	target_link_libraries(RenderManagerOpenGLHeadSpaceExample PRIVATE osvrRM::osvrRenderManagerCpp convenience_gldeps)
+    target_compile_features(RenderManagerOpenGLHeadSpaceExample PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
@@ -117,6 +129,7 @@ if(OSVRRM_HAVE_OPENGL_SUPPORT AND GLEW_FOUND)
 	# OpenGL Example program using the OpenGL Core profile
 	add_executable(RenderManagerOpenGLCoreExample RenderManagerOpenGLCoreExample.cpp)
 	target_link_libraries(RenderManagerOpenGLCoreExample PRIVATE osvrRM::osvrRenderManagerCpp GLEW::GLEW convenience_gldeps)
+    target_compile_features(RenderManagerOpenGLCoreExample PRIVATE cxx_range_for)
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
 			RenderManagerOpenGLCoreExample
@@ -129,16 +142,19 @@ if(OSVRRM_HAVE_OPENGL_SUPPORT AND GLEW_FOUND)
 	# impact of various latency-hiding techniques.
 	add_executable(AdjustableRenderingDelayOpenGL AdjustableRenderingDelayOpenGL.cpp)
 	target_link_libraries(AdjustableRenderingDelayOpenGL PRIVATE osvrRM::osvrRenderManagerCpp GLEW::GLEW convenience_gldeps)
+    target_compile_features(AdjustableRenderingDelayOpenGL PRIVATE cxx_range_for)
 
 	#-----------------------------------------------------------------------------
 	# OpenGL Example program that uses the Get()/Present() interface, not Render().
 	add_executable(RenderManagerOpenGLPresentExample RenderManagerOpenGLPresentExample.cpp)
 	target_link_libraries(RenderManagerOpenGLPresentExample PRIVATE osvrRM::osvrRenderManagerCpp GLEW::GLEW convenience_gldeps)
+    target_compile_features(RenderManagerOpenGLPresentExample PRIVATE cxx_range_for)
 
 	#-----------------------------------------------------------------------------
 	# OpenGL Example program that uses the Get()/Present() interface, not Render().
 	add_executable(RenderManagerOpenGLPresentSideBySideExample RenderManagerOpenGLPresentSideBySideExample.cpp)
 	target_link_libraries(RenderManagerOpenGLPresentSideBySideExample PRIVATE osvrRM::osvrRenderManagerCpp GLEW::GLEW convenience_gldeps)
+    target_compile_features(RenderManagerOpenGLPresentSideBySideExample PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
@@ -156,6 +172,7 @@ if(OSVRRM_HAVE_OPENGL_SUPPORT AND OPENGL_FOUND AND NOT APPLE)
 	# steadiness of the rendering in the absence of motion.
 	add_executable(SpinCubeOpenGL SpinCubeOpenGL.cpp font.c)
 	target_link_libraries(SpinCubeOpenGL PRIVATE osvrRM::osvrRenderManagerCpp convenience_gldeps vendored-vrpn vendored-quat)
+    target_compile_features(SpinCubeOpenGL PRIVATE cxx_range_for)
 
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS


### PR DESCRIPTION
This applies the same trick used to compile the RenderManager library to the examples.