### PR TITLE
Build and doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ that point to sets of non-open source code to build
 vendor-specific extensions to support direct rendering.  These were developed
 under non-disclosure agreements with the vendors.
 
-This code is built using CMake, and as of 2/23/2016 compiled on Windows, Linux
-(tested on Ubuntu) and Mac-OSX.  The Linux and Mac ports only support OpenGL and
-do not yet support direct-to-display (DirectMode) rendering.  The Android compile
-is done using the [OSVR-Android-Build](https://github.com/OSVR/OSVR-Android-Build)
-project.
-
 Most users, who don't have access to the NDA repos, get using:
 
 ```
@@ -26,6 +20,12 @@ Sensics internal users, who have access to the NDA repos, get using:
 ```
 git clone --recursive git@github.com:sensics/OSVR-RenderManager.git
 ```
+
+This code is built using CMake, and as of 2/23/2016 compiled on Windows, Linux
+(tested on Ubuntu) and Mac-OSX.  The Linux and Mac ports only support OpenGL and
+do not yet support direct-to-display (DirectMode) rendering.  The Android compile
+is done using the [OSVR-Android-Build](https://github.com/OSVR/OSVR-Android-Build)
+project.
 
 ## What RenderManager Provides
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # OSVR-RenderManager
 
 This repository holds the open-source code for the OSVR RenderManager developed by
-Sensics.  It is licensed under the Apache-2 license.  It has a set of submodules that point to sets of non-open source code to build
+Sensics.  It is licensed under the Apache-2 license.  It has a set of submodules
+that point to sets of non-open source code to build
 vendor-specific extensions to support direct rendering.  These were developed
 under non-disclosure agreements with the vendors.
 
-This code is built using CMake, and as of 1/26/2016 compiled on Windows, Linux
+This code is built using CMake, and as of 2/23/2016 compiled on Windows, Linux
 (tested on Ubuntu) and Mac-OSX.  The Linux and Mac ports only support OpenGL and
-do not yet support direct-to-display (DirectMode) rendering.
+do not yet support direct-to-display (DirectMode) rendering.  The Android compile
+is done using the [OSVR-Android-Build](https://github.com/OSVR/OSVR-Android-Build)
+project.
 
-As of 1/26/2016, the mac port does not run because of the lack of a compatibility
-OpenGL library on that platform.  It needs to be modified to use the Core library
-(needed for the distortion-correction shaders) and to not include the legacy
-OpenGL examples.  As of 2/15/2016, the RenderManager internal OpenGL code is
-entirely Core-compatible (and also GLES 2.0 compatible).  **Help wanted from
-the community to finish the mac port, see the Github issue for more info.**
+Most users, who don't have access to the NDA repos, get using:
+    git clone git@github.com:sensics/OSVR-RenderManager.git
+    cd OSVR-RenderManager
+    git submodule init vendor/vrpn
+    git submodule update
+
+Sensics internal users, who have access to the NDA repos, get using:
+    git clone --recursive git@github.com:sensics/OSVR-RenderManager.git
 
 ## What RenderManager Provides
 
@@ -83,8 +88,9 @@ mode will be enabled by a configuration-file setting.  It produces a separate re
 thread that re-warps and re-renders images at full rate even when the application
 renders too slowly to present a new image each frame.
 
-**Android** support is under development.  As of 2/15/2016, the OpenGL internal
-code is all compatible with OpenGL ES 2.0.  Work is underway to port RenderManager
+**Android** support is under development.  As of 2/23/2016, the OpenGL internal
+code is all compatible with OpenGL ES 2.0 and there is an OpenGLES example
+application that build and links (not yet tested).  Work is underway to port RenderManager
 to Android on top of the existing OSVR-Core port.
 
 **DirectMode/Linux** is planned as graphics-card vendors finish drivers

--- a/README.md
+++ b/README.md
@@ -13,13 +13,19 @@ is done using the [OSVR-Android-Build](https://github.com/OSVR/OSVR-Android-Buil
 project.
 
 Most users, who don't have access to the NDA repos, get using:
-    git clone git@github.com:sensics/OSVR-RenderManager.git
-    cd OSVR-RenderManager
-    git submodule init vendor/vrpn
-    git submodule update
+
+```
+git clone git@github.com:sensics/OSVR-RenderManager.git
+cd OSVR-RenderManager
+git submodule init vendor/vrpn
+git submodule update
+```
 
 Sensics internal users, who have access to the NDA repos, get using:
-    git clone --recursive git@github.com:sensics/OSVR-RenderManager.git
+
+```
+git clone --recursive git@github.com:sensics/OSVR-RenderManager.git
+```
 
 ## What RenderManager Provides
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(NOT (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vrpn/vrpn_Connection.h" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vrpn/submodules/hidapi/hidapi/hidapi.h"))
-	message(FATAL_ERROR "You are missing the VRPN git submodule or one of its submodules- you must have not done a recursive clone. You can get it now by running git submodule update --init --recursive from the root source directory.")
+if(NOT (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vrpn/vrpn_Connection.h"))
+	message(FATAL_ERROR "You are missing the VRPN git submodule. You can get it now by running git submodule init vendor/vrpn; git submodule update from the root source directory.")
 endif()
 
 set(BUILD_SHARED_LIBS OFF)
@@ -9,6 +9,7 @@ set(VRPN_GPL_SERVER FALSE CACHE BOOL "" FORCE)
 set(VRPN_BUILD_SERVER_LIBRARY FALSE CACHE BOOL "" FORCE)
 set(VRPN_BUILD_CLIENT_LIBRARY TRUE CACHE BOOL "" FORCE)
 set(VRPN_USE_LOCAL_HIDAPI FALSE CACHE BOOL "" FORCE)
+set(VRPN_USE_LOCAL_JSONCPP FALSE CACHE BOOL "" FORCE)
 add_subdirectory(vrpn)
 
 # Create an interface target to more easily consume VRPN internally.


### PR DESCRIPTION
Fixes things so that you can get VRPN without its submodules and build even if you don't have access to the NDA repositories.  Also adds build instructions for folks who can't read the NDA repos.