### PR TITLE
Atw math cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Open (non-NDA) files
 set (RenderManager_SOURCES
+	osvr/RenderKit/ComputeATW.h
 	osvr/RenderKit/RenderManagerBase.cpp
 	osvr/RenderKit/RenderManagerC.cpp
 	osvr/RenderKit/RenderKitGraphicsTransforms.cpp

--- a/osvr/RenderKit/ComputeATW.h
+++ b/osvr/RenderKit/ComputeATW.h
@@ -1,0 +1,134 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_ComputeATW_h_GUID_D936674E_AD5A_4AA8_86C0_C9E7D8D6F089
+#define INCLUDED_ComputeATW_h_GUID_D936674E_AD5A_4AA8_86C0_C9E7D8D6F089
+
+// Internal Includes
+#include "RenderManager.h"
+
+// Library/third-party includes
+#include <osvr/Util/EigenInterop.h>
+#include <osvr/Util/EigenCoreGeometry.h>
+
+// Standard includes
+// - none
+
+namespace ei = osvr::util::eigen_interop;
+
+namespace osvr {
+namespace renderkit {
+    inline Eigen::Projective3f computeATW(RenderInfo const& usedRenderInfo,
+                                          RenderInfo const& currentRenderInfo,
+                                          float assumedDepth) {
+
+        /// @todo For CAVE displays and fish-tank VR, the projection matrix
+        /// will not be the same between frames.  Make sure we're not
+        /// assuming here that it is.
+
+        // Compute the scale to use during forward transform.
+        // Scale the coordinates in X and Y so that they match the width and
+        // height of a window at the specified distance from the origin.
+        // We divide by the near clip distance to make the result match that
+        // at a unit distance and then multiply by the assumed depth.
+        float xScale = static_cast<float>(
+            (usedRenderInfo.projection.right - usedRenderInfo.projection.left) /
+            usedRenderInfo.projection.nearClip * assumedDepth);
+        float yScale = static_cast<float>(
+            (usedRenderInfo.projection.top - usedRenderInfo.projection.bottom) /
+            usedRenderInfo.projection.nearClip * assumedDepth);
+
+        // Compute the translation to use during forward transform.
+        // Translate the points so that their center lies in the middle of
+        // the view frustum pushed out to the specified distance from the
+        // origin.
+        // We take the mean coordinate of the two edges as the center that
+        // is to be moved to, and we move the space origin to there.
+        // We divide by the near clip distance to make the result match that
+        // at a unit distance and then multiply by the assumed depth.
+        // This assumes the default r texture coordinate of 0.
+        float xTrans = static_cast<float>(
+            (usedRenderInfo.projection.right + usedRenderInfo.projection.left) /
+            2.0 / usedRenderInfo.projection.nearClip * assumedDepth);
+        float yTrans = static_cast<float>(
+            (usedRenderInfo.projection.top + usedRenderInfo.projection.bottom) /
+            2.0 / usedRenderInfo.projection.nearClip * assumedDepth);
+        float zTrans = static_cast<float>(-assumedDepth);
+
+        // NOTE: These operations occur from the right to the left, so later
+        // actions on the list actually occur first because we're
+        // post-multiplying.
+
+        // Translate the points back to a coordinate system with the
+        // center at (0,0);
+        Eigen::Isometry3f postTranslation(
+            Eigen::Translation3f(0.5f, 0.5f, 0.0f));
+
+        // Scale the points so that they will fit into the range
+        // (-0.5,-0.5)
+        // to (0.5,0.5) (the inverse of the scale below).
+        Eigen::Isometry3f postScale(
+            Eigen::Scaling(1.0f / xScale, 1.0f / yScale, 1.0f));
+
+        // Translate the points so that the projection center will lie on
+        // the -Z axis (inverse of the translation below).
+        Eigen::Isometry3f postProjectionTranslate(
+            Eigen::Translation3f(-xTrans, -yTrans, -zTrans));
+
+        // Compute the forward last ModelView matrix.
+        OSVR_PoseState lastModelOSVR = usedRenderInfo.pose;
+        Eigen::Isometry3f lastModelViewTransform =
+            ei::map(lastModelOSVR).transform().cast<float>();
+
+        /// Compute the inverse of the current ModelView matrix.
+        OSVR_PoseState currentModelOSVR = currentRenderInfo.pose;
+
+        Eigen::Isometry3f currentModelViewInverseTransform =
+            ei::map(currentModelOSVR).transform().cast<float>().inverse();
+
+        /// Translate the origin to the center of the projected rectangle
+        Eigen::Isometry3f preProjectionTranslate(
+            Eigen::Translation3f(xTrans, yTrans, zTrans));
+
+        /// Scale from (-0.5,-0.5)/(0.5,0.5) to the actual frustum size
+        Eigen::Isometry3f preScale(Eigen::Scaling(xScale, yScale, 1.0f));
+
+        // Translate the points from a coordinate system that has (0.5,0.5)
+        // as the origin to one that has (0,0) as the origin.
+        Eigen::Isometry3f preTranslation(
+            Eigen::Translation3f(-0.5f, -0.5f, 0.0f));
+
+        /// Compute the full matrix by multiplying the parts.
+        /// @todo Does this have to be projective? it looks like combining
+        /// isometries...
+        Eigen::Projective3f full =
+            postTranslation * postScale * postProjectionTranslate *
+            lastModelViewTransform * currentModelViewInverseTransform *
+            preProjectionTranslate * preScale * preTranslation;
+        return full;
+    }
+
+} // namespace renderkit
+} // namespace osvr
+#endif // INCLUDED_ComputeATW_h_GUID_D936674E_AD5A_4AA8_86C0_C9E7D8D6F089

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -48,6 +48,7 @@ Russ Taylor working through ReliaSolve.com for Sensics, Inc.
 #endif
 
 #include "VendorIdTools.h"
+#include "ComputeATW.h"
 
 // OSVR Includes
 #include <osvr/ClientKit/InterfaceStateC.h>
@@ -1403,142 +1404,8 @@ namespace renderkit {
         }
 
         for (size_t eye = 0; eye < numEyes; eye++) {
-            /// @todo For CAVE displays and fish-tank VR, the projection matrix
-            /// will not be the same between frames.  Make sure we're not
-            /// assuming here that it is.
-
-            // Compute the scale to use during forward transform.
-            // Scale the coordinates in X and Y so that they match the width and
-            // height of a window at the specified distance from the origin.
-            // We divide by the near clip distance to make the result match that
-            // at a unit distance and then multiply by the assumed depth.
-            float xScale = static_cast<float>(
-                (usedRenderInfo[eye].projection.right -
-                 usedRenderInfo[eye].projection.left) /
-                usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float yScale = static_cast<float>(
-                (usedRenderInfo[eye].projection.top -
-                 usedRenderInfo[eye].projection.bottom) /
-                usedRenderInfo[eye].projection.nearClip * assumedDepth);
-
-            // Compute the translation to use during forward transform.
-            // Translate the points so that their center lies in the middle of
-            // the view frustum pushed out to the specified distance from the
-            // origin.
-            // We take the mean coordinate of the two edges as the center that
-            // is to be moved to, and we move the space origin to there.
-            // We divide by the near clip distance to make the result match that
-            // at a unit distance and then multiply by the assumed depth.
-            // This assumes the default r texture coordinate of 0.
-            float xTrans = static_cast<float>(
-                (usedRenderInfo[eye].projection.right +
-                 usedRenderInfo[eye].projection.left) /
-                2.0 / usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float yTrans = static_cast<float>(
-                (usedRenderInfo[eye].projection.top +
-                 usedRenderInfo[eye].projection.bottom) /
-                2.0 / usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float zTrans = static_cast<float>(-assumedDepth);
-
-            // NOTE: These operations occur from the right to the left, so later
-            // actions on the list actually occur first because we're
-            // post-multiplying.
-
-            // Translate the points back to a coordinate system with the
-            // center at (0,0);
-            Eigen::Isometry3f postTranslation(
-                Eigen::Translation3f(0.5f, 0.5f, 0.0f));
-
-            // Scale the points so that they will fit into the range
-            // (-0.5,-0.5)
-            // to (0.5,0.5) (the inverse of the scale below).
-            Eigen::Isometry3f postScale(
-                Eigen::Scaling(1.0f / xScale, 1.0f / yScale, 1.0f));
-
-            // Translate the points so that the projection center will lie on
-            // the -Z axis (inverse of the translation below).
-            Eigen::Isometry3f postProjectionTranslate(
-                Eigen::Translation3f(-xTrans, -yTrans, -zTrans));
-
-            // Compute the forward last ModelView matrix.
-            OSVR_PoseState lastModelOSVR = usedRenderInfo[eye].pose;
-#if 0
-            Eigen::Quaternionf lastModelViewRotation(
-                static_cast<float>(osvrQuatGetW(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetX(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetY(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetZ(&lastModelOSVR.rotation)));
-            Eigen::Affine3f lastModelViewTranslation(Eigen::Translation3f(
-                static_cast<float>(osvrVec3GetX(&lastModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetY(&lastModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetZ(&lastModelOSVR.translation))));
-            // Pull the translation out from above and then plop in the rotation
-            // matrix parts by hand.
-            Eigen::Matrix3f lastRot3 = lastModelViewRotation.toRotationMatrix();
-            Eigen::Matrix4f lastModelView = lastModelViewTranslation.matrix();
-            for (size_t i = 0; i < 3; i++) {
-                for (size_t j = 0; j < 3; j++) {
-                    lastModelView(i, j) = lastRot3(i, j);
-                }
-            }
-            Eigen::Projective3f lastModelViewTransform(lastModelView);
-#endif
-            Eigen::Isometry3f lastModelViewTransform =
-                ei::map(lastModelOSVR).transform().cast<float>();
-
-            /// Compute the inverse of the current ModelView matrix.
-            OSVR_PoseState currentModelOSVR = currentRenderInfo[eye].pose;
-#if 0
-            Eigen::Quaternionf currentModelViewRotation(
-                static_cast<float>(osvrQuatGetW(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetX(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetY(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetZ(&currentModelOSVR.rotation)));
-            Eigen::Affine3f currentModelViewTranslation(Eigen::Translation3f(
-                static_cast<float>(osvrVec3GetX(&currentModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetY(&currentModelOSVR.translation)),
-                static_cast<float>(
-                    osvrVec3GetZ(&currentModelOSVR.translation))));
-            // Pull the translation out from above and then plop in the rotation
-            // matrix parts by hand.
-            // @todo turn this into a transform catenation in the proper order.
-            Eigen::Matrix3f curRot3 =
-                currentModelViewRotation.toRotationMatrix();
-            Eigen::Matrix4f currentModelView =
-                currentModelViewTranslation.matrix();
-            for (size_t i = 0; i < 3; i++) {
-                for (size_t j = 0; j < 3; j++) {
-                    currentModelView(i, j) = curRot3(i, j);
-                }
-            }
-            Eigen::Matrix4f currentModelViewInverse =
-                currentModelView.inverse();
-            Eigen::Projective3f currentModelViewInverseTransform(
-                currentModelViewInverse);
-#endif
-            Eigen::Isometry3f currentModelViewInverseTransform =
-                ei::map(currentModelOSVR).transform().cast<float>().inverse();
-
-            /// Translate the origin to the center of the projected rectangle
-            Eigen::Isometry3f preProjectionTranslate(
-                Eigen::Translation3f(xTrans, yTrans, zTrans));
-
-            /// Scale from (-0.5,-0.5)/(0.5,0.5) to the actual frustum size
-            Eigen::Isometry3f preScale(Eigen::Scaling(xScale, yScale, 1.0f));
-
-            // Translate the points from a coordinate system that has (0.5,0.5)
-            // as the origin to one that has (0,0) as the origin.
-            Eigen::Isometry3f preTranslation(
-                Eigen::Translation3f(-0.5f, -0.5f, 0.0f));
-
-            /// Compute the full matrix by multiplying the parts.
-            /// @todo Does this have to be projective? it looks like combining
-            /// isometries...
-            Eigen::Projective3f full =
-                postTranslation * postScale * postProjectionTranslate *
-                lastModelViewTransform * currentModelViewInverseTransform *
-                preProjectionTranslate * preScale * preTranslation;
-
+            Eigen::Projective3f full = computeATW(
+                usedRenderInfo[eye], currentRenderInfo[eye], assumedDepth);
             // Store the result.
             /// @todo can we do this with eigen::map instead of memcp directly?
             matrix16 ATW;

--- a/osvr/RenderKit/RenderManagerD3DBase.cpp
+++ b/osvr/RenderKit/RenderManagerD3DBase.cpp
@@ -23,6 +23,7 @@ Sensics, Inc.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ComputeATW.h"
 #include "RenderManagerD3DBase.h"
 #include "GraphicsLibraryD3D11.h"
 #include <boost/assert.hpp>
@@ -614,137 +615,9 @@ namespace renderkit {
         }
 
         for (size_t eye = 0; eye < numEyes; eye++) {
-            /// @todo For CAVE displays and fish-tank VR, the projection matrix
-            /// will not be the same between frames.  Make sure we're not
-            /// assuming
-            /// here that it is.
-
-            // Compute the scale to use during forward transform.
-            // Scale the coordinates in X and Y so that they match the width and
-            // height of a window at the specified distance from the origin.
-            // We divide by the near clip distance to make the result match that
-            // at
-            // a unit distance and then multiply by the assumed depth.
-            float xScale = static_cast<float>(
-                (usedRenderInfo[eye].projection.right -
-                 usedRenderInfo[eye].projection.left) /
-                usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float yScale = static_cast<float>(
-                (usedRenderInfo[eye].projection.top -
-                 usedRenderInfo[eye].projection.bottom) /
-                usedRenderInfo[eye].projection.nearClip * assumedDepth);
-
-            // Compute the translation to use during forward transform.
-            // Translate the points so that their center lies in the middle of
-            // the
-            // view frustum pushed out to the specified distance from the
-            // origin.
-            // We take the mean coordinate of the two edges as the center that
-            // is
-            // to be moved to, and we move the space origin to there.
-            // We divide by the near clip distance to make the result match that
-            // at
-            // a unit distance and then multiply by the assumed depth.
-            // This assumes the default r texture coordinate of 0.
-            float xTrans = static_cast<float>(
-                (usedRenderInfo[eye].projection.right +
-                 usedRenderInfo[eye].projection.left) /
-                2.0 / usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float yTrans = static_cast<float>(
-                (usedRenderInfo[eye].projection.top +
-                 usedRenderInfo[eye].projection.bottom) /
-                2.0 / usedRenderInfo[eye].projection.nearClip * assumedDepth);
-            float zTrans = static_cast<float>(-assumedDepth);
-
-            // NOTE: These operations occur from the right to the left, so later
-            // actions on the list actually occur first because we're
-            // post-multiplying.
-
-            // Translate the points back to a coordinate system with the
-            // center at (0,0);
-            Eigen::Affine3f postTranslation(
-                Eigen::Translation3f(0.5f, 0.5f, 0.0f));
-
-            /// Scale the points so that they will fit into the range
-            /// (-0.5,-0.5)
-            // to (0.5,0.5) and flip in Y (the inverse of the scale below).
-            Eigen::Affine3f postScale(
-                Eigen::Scaling(1.0f / xScale, -1.0f / yScale, 1.0f));
-
-            /// Translate the points so that the projection center will lie on
-            // the -Z axis (inverse of the translation below).
-            Eigen::Affine3f postProjectionTranslate(
-                Eigen::Translation3f(-xTrans, -yTrans, -zTrans));
-
-            /// Compute the forward last ModelView matrix.
-            OSVR_PoseState lastModelOSVR = usedRenderInfo[eye].pose;
-            Eigen::Quaternionf lastModelViewRotation(
-                static_cast<float>(osvrQuatGetW(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetX(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetY(&lastModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetZ(&lastModelOSVR.rotation)));
-            Eigen::Affine3f lastModelViewTranslation(Eigen::Translation3f(
-                static_cast<float>(osvrVec3GetX(&lastModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetY(&lastModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetZ(&lastModelOSVR.translation))));
-            // Pull the translation out from above and then plop in the rotation
-            // matrix parts by hand.
-            Eigen::Matrix3f lastRot3 = lastModelViewRotation.toRotationMatrix();
-            Eigen::Matrix4f lastModelView = lastModelViewTranslation.matrix();
-            for (size_t i = 0; i < 3; i++) {
-                for (size_t j = 0; j < 3; j++) {
-                    lastModelView(i, j) = lastRot3(i, j);
-                }
-            }
-            Eigen::Projective3f lastModelViewTransform(lastModelView);
-
-            /// Compute the inverse of the current ModelView matrix.
-            OSVR_PoseState currentModelOSVR = currentRenderInfo[eye].pose;
-            Eigen::Quaternionf currentModelViewRotation(
-                static_cast<float>(osvrQuatGetW(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetX(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetY(&currentModelOSVR.rotation)),
-                static_cast<float>(osvrQuatGetZ(&currentModelOSVR.rotation)));
-            Eigen::Affine3f currentModelViewTranslation(Eigen::Translation3f(
-                static_cast<float>(osvrVec3GetX(&currentModelOSVR.translation)),
-                static_cast<float>(osvrVec3GetY(&currentModelOSVR.translation)),
-                static_cast<float>(
-                    osvrVec3GetZ(&currentModelOSVR.translation))));
-            // Pull the translation out from above and then plop in the rotation
-            // matrix parts by hand.
-            // @todo turn this into a transform catenation in the proper order.
-            Eigen::Matrix3f curRot3 =
-                currentModelViewRotation.toRotationMatrix();
-            Eigen::Matrix4f currentModelView =
-                currentModelViewTranslation.matrix();
-            for (size_t i = 0; i < 3; i++) {
-                for (size_t j = 0; j < 3; j++) {
-                    currentModelView(i, j) = curRot3(i, j);
-                }
-            }
-            Eigen::Matrix4f currentModelViewInverse =
-                currentModelView.inverse();
-            Eigen::Projective3f currentModelViewInverseTransform(
-                currentModelViewInverse);
-
-            /// Translate the origin to the center of the projected rectangle
-            Eigen::Affine3f preProjectionTranslate(
-                Eigen::Translation3f(xTrans, yTrans, zTrans));
-
-            /// Scale from (-0.5,-0.5)/(0.5,0.5) to the actual frustum size
-            /// and flip in Y.
-            Eigen::Affine3f preScale(Eigen::Scaling(xScale, -yScale, 1.0f));
-
-            // Translate the points from a coordinate system that has (0.5,0.5)
-            // as the origin to one that has (0,0) as the origin.
-            Eigen::Affine3f preTranslation(
-                Eigen::Translation3f(-0.5f, -0.5f, 0.0f));
-
-            /// Compute the full matrix by multiplying the parts.
-            Eigen::Projective3f full =
-                postTranslation * postScale * postProjectionTranslate *
-                lastModelView * currentModelViewInverse *
-                preProjectionTranslate * preScale * preTranslation;
+            Eigen::Projective3f full = computeATW(
+                usedRenderInfo[eye], currentRenderInfo[eye], assumedDepth);
+            Eigen::Matrix4f fullMatTranspose = full.matrix().transpose();
 
             // Store transpose of the result, because Direct3D stores matrices
             // in
@@ -752,12 +625,9 @@ namespace renderkit {
             // @todo Figure out how to handle the transpose or the handedness
             // change
             // in Eigen with a method or declaration.
+            /// @todo can we do this with eigen::map instead of memcp directly?
             matrix16 ATW;
-            for (size_t r = 0; r < 4; r++) {
-                for (size_t c = 0; c < 4; c++) {
-                    ATW.data[r * 4 + c] = full.matrix().data()[c * 4 + r];
-                }
-            }
+            memcpy(ATW.data, fullMatTranspose.data(), sizeof(ATW.data));
             m_asynchronousTimeWarps.push_back(ATW);
         }
         return true;


### PR DESCRIPTION
Ran across this pile of painful transformation from OSVR math to Eigen, and switched it quick to use the Eigen Interop header designed for that purpose. Then checked to see if it was elsewhere, and it was.

My system doesn't support ATW, so I couldn't anything but build, so please give it a try, and think about the @ todos I added - the more narrowly we constrain the transformation classes, the more optimization room we give Eigen (especially when there's an inversion...) Isometry is the narrowest, and includes translation and rotation, and also scale I believe (and even non-uniform scale I think...)  As long as you don't try to "cheat" by going through a matrix, it will automatically tell you if you try to do something that would take you into a different class of transforms.

pinging @JeroMiya on this one, since it's presumably code he wrote that I monkeyed with...