### PR TITLE
Client side prediction

### DIFF
--- a/examples/AdjustableRenderingDelayD3D.cpp
+++ b/examples/AdjustableRenderingDelayD3D.cpp
@@ -141,16 +141,23 @@ void RenderView(
 }
 
 void Usage(std::string name) {
-    std::cerr << "Usage: " << name << " millsecondRenderinDelay" << std::endl;
+    std::cerr << "Usage: " << name 
+      << " [-random]"
+      << " millsecondRenderinDelay" << std::endl;
+    std::cerr << "  -random: Each frame, delay from 0 to the specified delay"
+      << std::endl;
     exit(-1);
 }
 
 int main(int argc, char* argv[]) {
     // Parse the command line
     int delayMilliSeconds = 0;
+    bool do_random = false;
     int realParams = 0;
     for (int i = 1; i < argc; i++) {
-        if (argv[i][0] == '-') {
+        if (std::string("-random") == argv[i]) {
+          do_random = true;
+        } else if (argv[i][0] == '-') {
             Usage(argv[0]);
         } else
             switch (++realParams) {
@@ -399,9 +406,15 @@ int main(int argc, char* argv[]) {
         }
 
         // Delay the requested length of time.
+        // If random, replace our value with a random number up
+        // to the requested delay.
         // Busy-wait so we don't get swapped out longer than we wanted.
+        int actualDelayMS = delayMilliSeconds;
+        if (do_random) {
+          actualDelayMS = rand() % (delayMilliSeconds + 1);
+        }
         auto end =
-            highresclock::now() + std::chrono::milliseconds(delayMilliSeconds);
+          highresclock::now() + std::chrono::milliseconds(actualDelayMS);
         do {
         } while (highresclock::now() < end);
 

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -635,8 +635,6 @@ namespace renderkit {
                 m_distortionCorrection = false;
 
                 m_clientPredictionEnabled = false;
-                m_leftEyeDelayMS = 0;
-                m_rightEyeDelayMS = 0;
                 m_clientPredictionLocalTimeOverride = false;
 
                 m_graphicsLibrary = GraphicsLibrary();
@@ -716,8 +714,7 @@ namespace renderkit {
 
             /// Prediction settings.
             bool m_clientPredictionEnabled; //< Use client-side prediction?
-            float m_leftEyeDelayMS; //< Delay from present to left-eye start
-            float m_rightEyeDelayMS; //< Delay from present to right-eye start
+            std::vector<float> m_eyeDelaysMS; //< Delay from present to eye start
             bool m_clientPredictionLocalTimeOverride;  //< Override tracker timestamp?
 
             OSVRDisplayConfiguration

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -634,6 +634,11 @@ namespace renderkit {
 
                 m_distortionCorrection = false;
 
+                m_clientPredictionEnabled = false;
+                m_leftEyeDelayMS = 0;
+                m_rightEyeDelayMS = 0;
+                m_clientPredictionLocalTimeOverride = false;
+
                 m_graphicsLibrary = GraphicsLibrary();
             }
             typedef enum {
@@ -708,6 +713,12 @@ namespace renderkit {
             /// Render waits until at most this many ms before vsync to do
             /// timewarp (requires enable)
             float m_maxMSBeforeVsyncTimeWarp;
+
+            /// Prediction settings.
+            bool m_clientPredictionEnabled; //< Use client-side prediction?
+            float m_leftEyeDelayMS; //< Delay from present to left-eye start
+            float m_rightEyeDelayMS; //< Delay from present to right-eye start
+            bool m_clientPredictionLocalTimeOverride;  //< Override tracker timestamp?
 
             OSVRDisplayConfiguration
                 m_displayConfiguration; //< Display configuration

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -107,10 +107,10 @@ namespace renderkit {
         OSVR_TimeValue
             hardwareDisplayInterval; //< Time between refresh of display device
         OSVR_TimeValue timeSincelastVerticalRetrace; //< Time since the last
-        // retrace started
+        // retrace ended (the last presentation)
         OSVR_TimeValue timeUntilNextPresentRequired; //< How long until must
-        // present be made to make
-        // next vsync
+        // send images to RenderManager to display before the next frame is
+        // presented.
     } RenderTimingInfo;
 
     /// @brief Describes the parameters for a display callback handler.

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -714,7 +714,8 @@ namespace renderkit {
 
             /// Prediction settings.
             bool m_clientPredictionEnabled; //< Use client-side prediction?
-            std::vector<float> m_eyeDelaysMS; //< Delay from present to eye start
+            /// Static Delay + Delay from present to eye start
+            std::vector<float> m_eyeDelaysMS;
             bool m_clientPredictionLocalTimeOverride;  //< Override tracker timestamp?
 
             OSVRDisplayConfiguration

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2430,8 +2430,10 @@ namespace renderkit {
             pipelineConfig->getRenderOversampleFactor();
         p.m_clientPredictionEnabled =
           pipelineConfig->getclientPredictionEnabled();
-        p.m_eyeDelaysMS.push_back(pipelineConfig->getLeftEyeDelayMS());
-        p.m_eyeDelaysMS.push_back(pipelineConfig->getRightEyeDelayMS());
+        p.m_eyeDelaysMS.push_back(pipelineConfig->getStaticDelayMS() +
+          pipelineConfig->getLeftEyeDelayMS());
+        p.m_eyeDelaysMS.push_back(pipelineConfig->getStaticDelayMS() +
+          pipelineConfig->getRightEyeDelayMS());
         p.m_clientPredictionLocalTimeOverride =
           pipelineConfig->getclientPredictionLocalTimeOverride();
 

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2428,6 +2428,12 @@ namespace renderkit {
         p.m_renderOverfillFactor = pipelineConfig->getRenderOverfillFactor();
         p.m_renderOversampleFactor =
             pipelineConfig->getRenderOversampleFactor();
+        p.m_clientPredictionEnabled =
+          pipelineConfig->getclientPredictionEnabled();
+        p.m_leftEyeDelayMS = pipelineConfig->getLeftEyeDelayMS();
+        p.m_rightEyeDelayMS = pipelineConfig->getRightEyeDelayMS();
+        p.m_clientPredictionLocalTimeOverride =
+          pipelineConfig->getclientPredictionLocalTimeOverride();
 
         std::string jsonString;
         try {

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -134,7 +134,7 @@ static void PredictFuturePose(
     q_mult(newOrientation, fractionRotation, newOrientation);
 
     // Then put it back into OSVR format in the output pose.
-    osvrQuatFromQuatlib(&poseOut.rotation, newOrientation);
+    osvrQuatFromQuatlib(&out.rotation, newOrientation);
   }
 
   // If we have a linear velocity, apply it.

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2430,8 +2430,8 @@ namespace renderkit {
             pipelineConfig->getRenderOversampleFactor();
         p.m_clientPredictionEnabled =
           pipelineConfig->getclientPredictionEnabled();
-        p.m_leftEyeDelayMS = pipelineConfig->getLeftEyeDelayMS();
-        p.m_rightEyeDelayMS = pipelineConfig->getRightEyeDelayMS();
+        p.m_eyeDelaysMS.push_back(pipelineConfig->getLeftEyeDelayMS());
+        p.m_eyeDelaysMS.push_back(pipelineConfig->getRightEyeDelayMS());
         p.m_clientPredictionLocalTimeOverride =
           pipelineConfig->getclientPredictionLocalTimeOverride();
 

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -206,7 +206,9 @@ static double interpolate(double p1X, double p1Y, double val1, double p2X,
     q_vec_type ABC;
     q_vec_cross_product(ABC, v1, v2);
     if (q_vec_magnitude(ABC) == 0) {
-        std::cout << "XXX Zero-length vector" << std::endl;
+      // We can't get a normal, degenerate points, just return the first
+      // value.
+      return val1;
     }
     q_vec_normalize(ABC, ABC);
 

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -108,6 +108,7 @@ static void PredictFuturePose(
 
   // If we have a change in orientation, make it.
   if (vel.angularVelocityValid) {
+
     // Start out the new orientation at the original one
     // from OSVR.
     q_type newOrientation;
@@ -769,14 +770,6 @@ namespace renderkit {
 
                 ++count;
             } while (!proceed);
-            /*
-            static size_t iter = 0;
-            if (++iter > 60) {
-              std::cout << "XXX Did " << count << " iterations waiting" <<
-            std::endl;
-              iter = 0;
-            }
-            */
         }
 
         // Store the previous matrices we returned to the client and a new set
@@ -1446,8 +1439,11 @@ namespace renderkit {
               OSVR_VelocityState vel;
               vel.linearVelocityValid = false;
               vel.angularVelocityValid = false;
-              osvrGetVelocityState(m_roomFromHeadInterface, &timestamp,
-                &vel);
+              if (osvrGetVelocityState(m_roomFromHeadInterface, &timestamp,
+                  &vel) != OSVR_RETURN_SUCCESS) {
+                // We're okay with failure here, we just use a zero
+                // velocity to predict.
+              }
 
               // Predict the future pose of the head based on the velocity
               // information and how long we should predict.  Check the

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2355,10 +2355,10 @@ namespace renderkit {
 
         osvr::client::RenderManagerConfigPtr pipelineConfig;
         try {
+            // @todo
             // this should be a temporary workaround to an issue with
-            // RenderManagerConfig API
-            // in osvrClient. I think it's a C++ cross-dll boundary issue, and
-            // making it
+            // RenderManagerConfig APIin osvrClient. I think it's a
+            // C++ cross-dll boundary issue, and making it
             // a header-only lib might fix it, but we're moving the code here
             // for now.
             std::string configString = osvrRenderManagerGetString(context,


### PR DESCRIPTION
Adds client-side prediction.  Works with the DK2, but currently fails with HDK because the transform tree doesn't yet know how to handle adjusting velocities.  Does no harm because it needs to be explicitly turned on in the config file.