### PR TITLE
Fixing d3d issues

### DIFF
--- a/examples/LatencyTestD3DExample.cpp
+++ b/examples/LatencyTestD3DExample.cpp
@@ -167,11 +167,9 @@ static void myTrackerCallback(void* userdata,
     }
 }
 
-bool SetupRendering(osvr::renderkit::GraphicsLibrary library,
-                    osvr::renderkit::RenderBuffer buffers) {
+bool SetupRendering(osvr::renderkit::GraphicsLibrary library) {
     ID3D11Device* device = library.D3D11->device;
     ID3D11DeviceContext* context = library.D3D11->context;
-    ID3D11RenderTargetView* renderTargetView = buffers.D3D11->colorBufferView;
 
     // Setup vertex shader
     auto hr = device->CreateVertexShader(g_triangle_vs, sizeof(g_triangle_vs),
@@ -336,7 +334,7 @@ int main(int argc, char* argv[]) {
     }
 
     // Set up the rendering state we need.
-    if (!SetupRendering(ret.library, ret.buffers)) {
+    if (!SetupRendering(ret.library)) {
         return 3;
     }
 

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -241,7 +241,6 @@ namespace renderkit {
         typedef struct {
             OpenStatus status;       //< How did the opening go?
             GraphicsLibrary library; //< Graphics library pointers
-            RenderBuffer buffers;    //< Render buffer pointers
         } OpenResults;
 
         /// @brief Opens the window or display to be used for rendering.

--- a/osvr/RenderKit/RenderManagerD3D.cpp
+++ b/osvr/RenderKit/RenderManagerD3D.cpp
@@ -231,7 +231,6 @@ namespace renderkit {
         // Done, we now have an open window to use.
         m_displayOpen = true;
         ret.library = m_library;
-        ret.buffers = m_buffers;
         return ret;
     }
 

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -97,9 +97,26 @@ namespace osvr {
             OpenResults OpenDisplay() override {
                 std::lock_guard<std::mutex> lock(mLock);
 
+                OpenResults ret;
+
+                // Set the device and context we're going to use
+                // but don't open an additional display -- we're
+                // going to pass all display-related things down to
+                // our render thread.
+                // @todo Consider whether we want to just return
+                // the device and context of our render-thread's
+                // RenderManager
+                if (!SetDeviceAndContext()) {
+                  std::cerr << "RenderManagerD3D11ATW::OpenDisplay: Could not "
+                    "create device and context"
+                    << std::endl;
+                  ret.status = OpenStatus::FAILURE;
+                  return ret;
+                }
+
                 // Try to open the display in the harnessed
                 // RenderManager.  Return false if it fails.
-                OpenResults ret = mRenderManager->OpenDisplay();
+                ret = mRenderManager->OpenDisplay();
                 if (ret.status == OpenStatus::FAILURE) {
                   std::cerr << "RenderManagerD3D11ATW::OpenDisplay: Could not "
                     "open display in harnessed RenderManager"

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -134,14 +134,9 @@ namespace osvr {
                 m_library.D3D11->device = m_D3D11device;
                 m_library.D3D11->context = m_D3D11Context;
 
-                // Fill in our library and buffers, rather than those of
-                // the harnessed RenderManager, since these are the ones
+                // Fill in our library, rather than that of
+                // the harnessed RenderManager, since this is the one
                 // that the client will deal with.
-                // @todo Figure out what to do about the buffers
-                // (They may only be needed in the callback path, so we
-                // should consider pulling them out of the present path
-                // and not returning them here.)
-                ret.buffers = m_buffers;
                 ret.library = m_library;
                 return ret;
             }

--- a/osvr/RenderKit/RenderManagerD3D11C.cpp
+++ b/osvr/RenderKit/RenderManagerD3D11C.cpp
@@ -39,13 +39,18 @@ namespace {
 inline void
 ConvertGraphicsLibrary(const OSVR_GraphicsLibraryD3D11& graphicsLibrary,
                        osvr::renderkit::GraphicsLibrary& graphicsLibraryOut) {
-    graphicsLibraryOut.D3D11 = nullptr;
-    graphicsLibraryOut.OpenGL = nullptr;
-    osvr::renderkit::GraphicsLibraryD3D11* gld3d11 =
+    // If we have non-NULL entries for either, then we construct a
+    // place to put them.  Otherwise, we leave the device with its
+    // default NULL pointer so that it will not think the contents
+    // are valid.
+    if (graphicsLibrary.device != nullptr ||
+        graphicsLibrary.context != nullptr) {
+      osvr::renderkit::GraphicsLibraryD3D11* gld3d11 =
         new osvr::renderkit::GraphicsLibraryD3D11();
-    gld3d11->device = graphicsLibrary.device;
-    gld3d11->context = graphicsLibrary.context;
-    graphicsLibraryOut.D3D11 = gld3d11;
+      gld3d11->device = graphicsLibrary.device;
+      gld3d11->context = graphicsLibrary.context;
+      graphicsLibraryOut.D3D11 = gld3d11;
+    }
 }
 
 inline void

--- a/osvr/RenderKit/RenderManagerD3D11C.h
+++ b/osvr/RenderKit/RenderManagerD3D11C.h
@@ -61,7 +61,6 @@ typedef struct OSVR_RenderBufferD3D11 {
 typedef struct OSVR_OpenResultsD3D11 {
     OSVR_OpenStatus status;
     OSVR_GraphicsLibraryD3D11 library;
-    OSVR_RenderBufferD3D11 buffers;
 } OSVR_OpenResultsD3D11;
 
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrCreateRenderManagerD3D11(

--- a/osvr/RenderKit/RenderManagerD3DBase.cpp
+++ b/osvr/RenderKit/RenderManagerD3DBase.cpp
@@ -182,8 +182,7 @@ namespace renderkit {
       if (m_params.m_graphicsLibrary.D3D11 != nullptr) {
         m_D3D11device = m_params.m_graphicsLibrary.D3D11->device;
         m_D3D11Context = m_params.m_graphicsLibrary.D3D11->context;
-      }
-      else {
+      } else {
         D3D_FEATURE_LEVEL acceptibleAPI = D3D_FEATURE_LEVEL_11_0;
         D3D_FEATURE_LEVEL foundAPI;
 

--- a/osvr/RenderKit/RenderManagerD3DBase.cpp
+++ b/osvr/RenderKit/RenderManagerD3DBase.cpp
@@ -391,7 +391,6 @@ namespace renderkit {
       
         OpenResults ret;
         ret.library = m_library;
-        ret.buffers = m_buffers;
         ret.status = COMPLETE; // Until we hear otherwise
         if (!doingOkay()) {
             ret.status = FAILURE;

--- a/osvr/RenderKit/RenderManagerD3DBase.h
+++ b/osvr/RenderKit/RenderManagerD3DBase.h
@@ -48,6 +48,11 @@ namespace renderkit {
         // Is the renderer currently working?
         bool doingOkay() override { return m_doingOkay; }
 
+        // Creates the D3D11 device and context to be used
+        // to draw things into our window unless they have
+        // already been filled in.
+        virtual bool SetDeviceAndContext();
+
         // Opens the D3D renderer we're going to use.
         OpenResults OpenDisplay() override;
 

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
@@ -169,7 +169,6 @@ namespace renderkit {
         // Fill in our library with the things the application may need to
         // use to do its graphics state set-up.
         ret.library = m_library;
-        ret.buffers = m_buffers;
         m_displayOpen = true;
         return ret;
     }

--- a/osvr/RenderKit/RenderManagerImpl.h
+++ b/osvr/RenderKit/RenderManagerImpl.h
@@ -160,7 +160,6 @@ osvrRenderManagerOpenDisplayImpl(OSVR_RenderManagerType renderManager,
             break;
         }
         ConvertGraphicsLibrary(results.library, _openResultsOut.library);
-        ConvertRenderBuffer(results.buffers, _openResultsOut.buffers);
     }
     return results.status == osvr::renderkit::RenderManager::FAILURE
                ? OSVR_RETURN_FAILURE

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -353,7 +353,6 @@ namespace renderkit {
 
         OpenResults ret;
         ret.library = m_library;
-        ret.buffers = m_buffers;
         ret.status = COMPLETE; // Until we hear otherwise
         if (!doingOkay()) {
             ret.status = FAILURE;
@@ -520,7 +519,6 @@ namespace renderkit {
         // Fill in our library with the things the application may need to
         // use to do its graphics state set-up.
         ret.library = m_library;
-        ret.buffers = m_buffers;
 
         checkForGLError("RenderManagerOpenGL::OpenDisplay end");
 

--- a/osvr/RenderKit/RenderManagerOpenGLC.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGLC.cpp
@@ -37,11 +37,16 @@
 inline void
 ConvertGraphicsLibrary(const OSVR_GraphicsLibraryOpenGL& graphicsLibrary,
                        osvr::renderkit::GraphicsLibrary& graphicsLibraryOut) {
-    graphicsLibraryOut.D3D11 = nullptr;
-    graphicsLibraryOut.OpenGL = nullptr;
+  // If we have non-NULL entries for either, then we construct a
+  // place to put them.  Otherwise, we leave the device with its
+  // default NULL pointer so that it will not think the contents
+  // are valid.
+  //if (graphicsLibrary.device != nullptr ||
+  //    graphicsLibrary.context != nullptr) {
     // osvr::renderkit::GraphicsLibraryOpenGL *glogl = new
     // osvr::renderkit::GraphicsLibraryOpenGL();
     // graphicsLibraryOut.OpenGL = glogl;
+  //}
 }
 
 inline void


### PR DESCRIPTION
Fixes issues with multi-GPU under D3D11 and crashes when NULL device and contexts are passed in using the C API.

Also removes structures from the OpenDisplay return structure that are not needed; this "fixes" problems when client programs expect them to be filled in with something useful and they are not.  This was a holdover from an earlier implementation.

The last change modifies client-facing structures in the C++ and C APIs.