### PR TITLE
InfoLog output on distortion shader compile error

### DIFF
--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -453,10 +453,15 @@ namespace renderkit {
         glShaderSource(vertexShaderId, 1, &distortionVertexShader, nullptr);
         glCompileShader(vertexShaderId);
         if (!checkShaderError(vertexShaderId)) {
+            GLint infoLogLength;
+            glGetShaderiv(vertexShaderId, GL_INFO_LOG_LENGTH, &infoLogLength);
+            GLchar* strInfoLog = new GLchar[infoLogLength + 1];
+            glGetShaderInfoLog(vertexShaderId, infoLogLength, NULL, strInfoLog);
+
             removeOpenGLContexts();
             std::cerr << "RenderManagerOpenGL::OpenDisplay: Could not "
-                         "construct vertex shader "
-                      << std::endl;
+                         "construct vertex shader:"
+                      << std::endl << strInfoLog << std::endl;
             ret.status = FAILURE;
             return ret;
         }
@@ -465,10 +470,15 @@ namespace renderkit {
         glShaderSource(fragmentShaderId, 1, &distortionFragmentShader, nullptr);
         glCompileShader(fragmentShaderId);
         if (!checkShaderError(fragmentShaderId)) {
+            GLint infoLogLength;
+            glGetShaderiv(fragmentShaderId, GL_INFO_LOG_LENGTH, &infoLogLength);
+            GLchar* strInfoLog = new GLchar[infoLogLength + 1];
+            glGetShaderInfoLog(fragmentShaderId, infoLogLength, NULL, strInfoLog);
+
             removeOpenGLContexts();
             std::cerr << "RenderManagerOpenGL::OpenDisplay: Could not "
-                         "construct fragment shader "
-                      << std::endl;
+                         "construct fragment shader:"
+                      << std::endl << strInfoLog << std::endl;
             ret.status = FAILURE;
             return ret;
         }


### PR DESCRIPTION
```
RenderManagerOpenGL::OpenDisplay: Could not construct vertex shader
```
is not the best error message, when OpenGL can tell us what's wrong. For example this is the output with mesa drivers with the OpenGL Compatibility profile (mesa drivers only support GLSL 310+ with the Core profile):
```
RenderManagerOpenGL::OpenDisplay: Could not construct vertex shader:
0:1(10): error: GLSL 3.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, and 3.00 ES
```