### PR TITLE
Replacing shader resource info pulled from the texture with sending a…

### DIFF
--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -592,19 +592,6 @@ namespace osvr {
 
                     // We can't use the render thread's ID3D11RenderTargetView. Create one from
                     // the ATW's ID3D11Texture2D handle.
-
-                    // Find out the format of the texture by looking at its info.
-                    D3D11_TEXTURE2D_DESC info;
-                    texture2D->GetDesc(&info);
-
-                    // Fill in the resource view for your render texture buffer here
-                    D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
-                    memset(&renderTargetViewDesc, 0, sizeof(renderTargetViewDesc));
-                    // This must match what was created in the texture to be rendered
-                    renderTargetViewDesc.Format = info.Format;
-                    renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-                    renderTargetViewDesc.Texture2D.MipSlice = 0;
-
                     newInfo.atwBuffer.D3D11 = new osvr::renderkit::RenderBufferD3D11();
                     newInfo.atwBuffer.D3D11->colorBuffer = texture2D;
 

--- a/osvr/RenderKit/RenderManagerD3DBase.cpp
+++ b/osvr/RenderKit/RenderManagerD3DBase.cpp
@@ -1190,15 +1190,12 @@ namespace renderkit {
 
         //====================================================================
         // Create the shader resource view.
-        D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc = {};
-        shaderResourceViewDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-        shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
-        shaderResourceViewDesc.Texture2D.MipLevels = 1;
 
+        // We pass a nullptr to the description, resulting in a view that
+        // can access the entire resource.
         ID3D11ShaderResourceView* renderTextureResourceView;
         hr = m_D3D11device->CreateShaderResourceView(
-            params.m_buffer.D3D11->colorBuffer, &shaderResourceViewDesc,
+            params.m_buffer.D3D11->colorBuffer, nullptr,
             &renderTextureResourceView);
         if (FAILED(hr)) {
             std::cerr << "RenderManagerD3D11Base::PresentEye(): Could not "


### PR DESCRIPTION
… nullptr, which means to just share whatever is in the texture.  Removed code getting (and not using) this information in ATW.