### PR TITLE
Support restart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,12 @@ else()
 endif()
 
 #-----------------------------------------------------------------------------
+# SDL init/quit handler code that makes sure we only do it once.
+if (SDL2_FOUND)
+	list(APPEND RenderManager_SOURCES osvr/RenderKit/RenderManagerSDLInitQuit.cpp osvr/RenderKit/RenderManagerSDLInitQuit.h )
+endif()
+
+#-----------------------------------------------------------------------------
 # OpenGL library as a stand-alone renderer not wrapping D3D
 if ( ( (OPENGL_FOUND AND GLEW_FOUND) OR OPENGLES2_FOUND ) AND SDL2_FOUND)
 	list(APPEND RenderManager_SOURCES osvr/RenderKit/RenderManagerOpenGL.cpp osvr/RenderKit/RenderManagerOpenGL.h osvr/RenderKit/RenderManagerOpenGLC.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -58,9 +58,7 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 			RenderManagerD3DTest2D
 			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
-endif()
 
-if(OSVRRM_HAVE_D3D11_SUPPORT)
 	#-----------------------------------------------------------------------------
 	# Latency test program
 	add_executable(LatencyTestD3DExample LatencyTestD3DExample.cpp ${COMMON_D3D_2D_SOURCES})
@@ -78,9 +76,7 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 			RenderManagerD3DHeadSpaceExample
 			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
-endif()
 
-if(OSVRRM_HAVE_D3D11_SUPPORT)
 	#-----------------------------------------------------------------------------
 	# D3D program that spins the world cube at a constant rate, useful for testing the
 	# steadiness of the rendering in the absence of motion.
@@ -91,6 +87,20 @@ if(OSVRRM_HAVE_D3D11_SUPPORT)
 	if(OSVRRM_INSTALL_EXAMPLES)
 		install(TARGETS
 			SpinCubeD3D
+			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+	endif()
+
+	#-----------------------------------------------------------------------------
+	# D3D program that restarts the RenderManager every once in a while.  For
+	# the display, it spins the world cube at a constant rate, useful for testing the
+	# steadiness of the rendering in the absence of motion.
+	add_executable(RestartD3D RestartD3D.cpp ${COMMON_D3D_SOURCES})
+	target_link_libraries(RestartD3D PRIVATE osvrRM::osvrRenderManagerCpp vendored-vrpn vendored-quat D3D11)
+    target_compile_features(RestartD3D PRIVATE cxx_range_for)
+
+	if(OSVRRM_INSTALL_EXAMPLES)
+		install(TARGETS
+			RestartD3D
 			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 	endif()
 endif()

--- a/examples/RenderManagerOpenGLSharedContextExample.cpp
+++ b/examples/RenderManagerOpenGLSharedContextExample.cpp
@@ -25,6 +25,7 @@
 
 // Internal Includes
 #include <osvr/RenderKit/RenderManager.h>
+#include <osvr/RenderKit/RenderManagerSDLInitQuit.h>
 #include <osvr/ClientKit/Context.h>
 
 // Library/third-party includes
@@ -522,7 +523,7 @@ int main(int argc, char* argv[]) {
 
     // Use SDL to open a window and then get an OpenGL context for us.
     // Note: This window is not the one that will be used for rendering.
-    if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
+    if (!osvr::renderkit::SDLInitQuit()) {
       std::cerr << "Could not initialize SDL"
         << std::endl;
       return 100;

--- a/examples/RestartD3D.cpp
+++ b/examples/RestartD3D.cpp
@@ -164,6 +164,9 @@ osvr::renderkit::RenderManager* GetNewRenderManager(
     std::cout << "Deleting old RenderManager" << std::endl;
     delete render;
     render = nullptr;
+
+    // Wait a bit to give any HMD time to cycle
+    vrpn_SleepMsecs(500);
   }
 
   // Open Direct3D and set up the context for rendering to
@@ -494,13 +497,12 @@ int main(int argc, char* argv[]) {
 
         // Print timing info
         struct timeval nowFrames;
-        vrpn_gettimeofday(&nowFrames, nullptr);
+        vrpn_gettimeofday(&nowFrames);
         double duration = vrpn_TimevalDurationSeconds(nowFrames, startFrames);
         countFrames++;
         if (duration >= 2.0) {
             std::cout << "Rendering at " << countFrames / duration << " fps"
                       << std::endl;
-            startFrames = nowFrames;
             countFrames = 0;
 
             std::cout << "Creating new RenderManager" << std::endl;
@@ -518,6 +520,7 @@ int main(int argc, char* argv[]) {
                 << std::endl;
               return 201;
             }
+            vrpn_gettimeofday(&startFrames);
         }
     }
 

--- a/examples/RestartD3D.cpp
+++ b/examples/RestartD3D.cpp
@@ -1,0 +1,531 @@
+/** @file
+    @brief Example program that uses the OSVR direct-to-display interface
+           and D3D to render a scene with a spinning cube.  It also does
+           a restart (deletion and contruction) of the RenderManager it
+           is using from time to time.
+
+    @date 2015
+
+    @author
+    Russ Taylor <russ@sensics.com>
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/ClientKit/Context.h>
+#include <osvr/ClientKit/Interface.h>
+#include <osvr/RenderKit/RenderManager.h>
+
+// Library/third-party includes
+#include <windows.h>
+#include <initguid.h>
+#include <d3d11.h>
+#include <wrl.h>
+#include <DirectXMath.h>
+#include <vrpn_Shared.h>
+#include <quat.h>
+
+// Standard includes
+#include <iostream>
+#include <string>
+#include <stdlib.h> // For exit()
+
+// This must come after we include <d3d11.h> so its pointer types are defined.
+#include <osvr/RenderKit/GraphicsLibraryD3D11.h>
+
+// Includes from our own directory
+#include "pixelshader3d.h"
+#include "vertexshader3d.h"
+
+using namespace DirectX;
+
+#include "D3DCube.h"
+#include "D3DSimpleShader.h"
+
+// Set to true when it is time for the application to quit.
+// Handlers below that set it to true when the user causes
+// any of a variety of events so that we shut down the system
+// cleanly.  This only works on Windows, but so does D3D...
+static bool quit = false;
+static Cube roomCube(5.0f, true);
+static SimpleShader simpleShader;
+
+std::vector<osvr::renderkit::RenderBuffer> renderBuffers;
+std::vector<ID3D11Texture2D*> depthStencilTextures;
+std::vector<ID3D11DepthStencilView*> depthStencilViews;
+ID3D11DepthStencilState* depthStencilState;
+
+#ifdef _WIN32
+// Note: On Windows, this runs in a different thread from
+// the main application.
+static BOOL CtrlHandler(DWORD fdwCtrlType) {
+    switch (fdwCtrlType) {
+    // Handle the CTRL-C signal.
+    case CTRL_C_EVENT:
+    // CTRL-CLOSE: confirm that the user wants to exit.
+    case CTRL_CLOSE_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        quit = true;
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+#endif
+
+// This callback sets a boolean value whose pointer is passed in to
+// the state of the button that was pressed.  This lets the callback
+// be used to handle any button press that just needs to update state.
+void myButtonCallback(void* userdata, const OSVR_TimeValue* /*timestamp*/,
+                      const OSVR_ButtonReport* report) {
+    bool* result = static_cast<bool*>(userdata);
+    *result = (report->state != 0);
+}
+
+// Callbacks to draw things in world space, left-hand space, and right-hand
+// space.
+void RenderView(
+    const osvr::renderkit::RenderInfo& renderInfo //< Info needed to render
+    ,
+    ID3D11RenderTargetView* renderTargetView,
+    ID3D11DepthStencilView* depthStencilView) {
+    // Make sure our pointers are filled in correctly.  The config file selects
+    // the graphics library to use, and may not match our needs.
+    if (renderInfo.library.D3D11 == nullptr) {
+        std::cerr
+            << "SetupDisplay: No D3D11 GraphicsLibrary, this should not happen"
+            << std::endl;
+        return;
+    }
+
+    auto context = renderInfo.library.D3D11->context;
+    auto device = renderInfo.library.D3D11->device;
+    float projectionD3D[16];
+    float viewD3D[16];
+    XMMATRIX identity = XMMatrixIdentity();
+
+    // Set up to render to the textures for this eye
+    context->OMSetRenderTargets(1, &renderTargetView, depthStencilView);
+
+    // Set up the viewport we're going to draw into.
+    CD3D11_VIEWPORT viewport(static_cast<float>(renderInfo.viewport.left),
+                             static_cast<float>(renderInfo.viewport.lower),
+                             static_cast<float>(renderInfo.viewport.width),
+                             static_cast<float>(renderInfo.viewport.height));
+    context->RSSetViewports(1, &viewport);
+
+    // Make a grey background
+    FLOAT colorRgba[4] = {0.3f, 0.3f, 0.3f, 1.0f};
+    context->ClearRenderTargetView(renderTargetView, colorRgba);
+    context->ClearDepthStencilView(
+        depthStencilView, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+
+    osvr::renderkit::OSVR_PoseState_to_D3D(viewD3D, renderInfo.pose);
+    osvr::renderkit::OSVR_Projection_to_D3D(projectionD3D,
+                                            renderInfo.projection);
+
+    XMMATRIX xm_projectionD3D(projectionD3D), xm_viewD3D(viewD3D);
+
+    // draw room
+    simpleShader.use(device, context, xm_projectionD3D, xm_viewD3D, identity);
+    roomCube.draw(device, context);
+}
+
+void Usage(std::string name) {
+    std::cerr << "Usage: " << name << " spinRateRadiansPerSecond" << std::endl;
+    exit(-1);
+}
+
+osvr::renderkit::RenderManager* GetNewRenderManager(
+  osvr::clientkit::ClientContext &context,
+  osvr::renderkit::GraphicsLibrary &library)
+{
+  // We keep a static pointer to a RenderManager so we
+  // know if we've been called before.  If so, we delete the
+  // old RenderManager before creating a new one.
+  static osvr::renderkit::RenderManager* render = nullptr;
+  if (render != nullptr) {
+    std::cout << "Deleting old RenderManager" << std::endl;
+    delete render;
+    render = nullptr;
+  }
+
+  // Open Direct3D and set up the context for rendering to
+  // an HMD.  Do this using the OSVR RenderManager interface,
+  // which maps to the nVidia or other vendor direct mode
+  // to reduce the latency.
+  std::cout << "Constructing new RenderManager" << std::endl;
+  render =
+    osvr::renderkit::createRenderManager(context.get(), "Direct3D11",
+    library);
+  if ((render == nullptr) || (!render->doingOkay())) {
+    std::cerr << "Could not create RenderManager" << std::endl;
+    return nullptr;
+  }
+
+  // Open the display and make sure this worked.
+  osvr::renderkit::RenderManager::OpenResults ret = render->OpenDisplay();
+  if (ret.status == osvr::renderkit::RenderManager::OpenStatus::FAILURE) {
+    std::cerr << "Could not open display" << std::endl;
+    return nullptr;
+  }
+  if (ret.library.D3D11 == nullptr) {
+    std::cerr << "Attempted to run a Direct3D11 program with a config file "
+      << "that specified a different rendering library."
+      << std::endl;
+    return nullptr;
+  }
+
+  // We're done constructing and setting it up, ready to use it.
+  return render;
+}
+
+int main(int argc, char* argv[]) {
+    // Parse the command line
+    double spinRateRadiansPerSecond = 0.5;
+    int realParams = 0;
+    for (int i = 1; i < argc; i++) {
+#if 0
+        if (argv[i][0] == '-') {
+            Usage(argv[0]);
+        }
+        else
+#endif
+        switch (++realParams) {
+        case 1:
+            spinRateRadiansPerSecond = atof(argv[i]);
+            break;
+        default:
+            Usage(argv[0]);
+        }
+    }
+    if (realParams > 1) {
+        Usage(argv[0]);
+    }
+
+    // Get an OSVR client context to use to access the devices
+    // that we need.
+    osvr::clientkit::ClientContext context("org.RenderManager.SpinCubeD3D");
+
+    // Construct button devices and connect them to a callback
+    // that will set the "quit" variable to true when it is
+    // pressed.  Use button "1" on the left-hand or
+    // right-hand controller.
+    osvr::clientkit::Interface leftButton1 =
+        context.getInterface("/controller/left/1");
+    leftButton1.registerCallback(&myButtonCallback, &quit);
+
+    osvr::clientkit::Interface rightButton1 =
+        context.getInterface("/controller/right/1");
+    rightButton1.registerCallback(&myButtonCallback, &quit);
+
+    // Create a D3D11 device and context to be used, rather than
+    // having RenderManager make one for us.  This is an example
+    // of using an external one, which would be needed for clients
+    // that already have a rendering pipeline, like Unity.
+    ID3D11Device* myDevice = nullptr;         // Fill this in
+    ID3D11DeviceContext* myContext = nullptr; // Fill this in.
+
+    // Here, we open the device and context ourselves, but if you
+    // are working with a render library that provides them for you,
+    // just stick them into the values rather than constructing
+    // them.  (This is a bit of a toy example, because we could
+    // just let RenderManager do this work for us and use the library
+    // it sends back.  However, it does let us set parameters on the
+    // device and context construction the way that we want, so it
+    // might be useful.  Be sure to get D3D11 and have set
+    // D3D11_CREATE_DEVICE_BGRA_SUPPORT in the device/context
+    // creation, however it is done).
+    D3D_FEATURE_LEVEL acceptibleAPI = D3D_FEATURE_LEVEL_11_0;
+    D3D_FEATURE_LEVEL foundAPI;
+    auto hr =
+      D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+      D3D11_CREATE_DEVICE_BGRA_SUPPORT, &acceptibleAPI, 1,
+      D3D11_SDK_VERSION, &myDevice, &foundAPI, &myContext);
+    if (FAILED(hr)) {
+      std::cerr << "Could not create D3D11 device and context" << std::endl;
+      return -1;
+    }
+
+    // Put the device and context into a structure to let RenderManager
+    // know to use this one rather than creating its own.
+    osvr::renderkit::GraphicsLibrary library;
+    library.D3D11 = new osvr::renderkit::GraphicsLibraryD3D11;
+    library.D3D11->device = myDevice;
+    library.D3D11->context = myContext;
+
+    osvr::renderkit::RenderManager* render = GetNewRenderManager(context,
+      library);
+    if (render == nullptr) {
+      std::cerr << "Could not construct initial RenderManager" << std::endl;
+      return 100;
+    }
+
+    // Set up a handler to cause us to exit cleanly.
+#ifdef _WIN32
+    SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler, TRUE);
+#endif
+
+    // Do a call to get the information we need to construct our
+    // color and depth render-to-texture buffers.
+    std::vector<osvr::renderkit::RenderInfo> renderInfo;
+    context.update();
+    renderInfo = render->GetRenderInfo();
+
+    // Set up the vector of textures to render to and any framebuffer
+    // we need to group them.
+
+    for (size_t i = 0; i < renderInfo.size(); i++) {
+
+      // The color buffer for this eye.  We need to put this into
+      // a generic structure for the Present function, but we only need
+      // to fill in the Direct3D portion.
+      //  Note that this texture format must be RGBA and unsigned byte,
+      // so that we can present it to Direct3D for DirectMode.
+      ID3D11Texture2D* D3DTexture = nullptr;
+      unsigned width = static_cast<int>(renderInfo[i].viewport.width);
+      unsigned height = static_cast<int>(renderInfo[i].viewport.height);
+
+      // Initialize a new render target texture description.
+      D3D11_TEXTURE2D_DESC textureDesc = {};
+      textureDesc.Width = width;
+      textureDesc.Height = height;
+      textureDesc.MipLevels = 1;
+      textureDesc.ArraySize = 1;
+      textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+      textureDesc.SampleDesc.Count = 1;
+      textureDesc.SampleDesc.Quality = 0;
+      textureDesc.Usage = D3D11_USAGE_DEFAULT;
+      // We need it to be both a render target and a shader resource
+      textureDesc.BindFlags =
+        D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+      textureDesc.CPUAccessFlags = 0;
+      textureDesc.MiscFlags = 0;
+
+      // Create a new render target texture to use.
+      hr = renderInfo[i].library.D3D11->device->CreateTexture2D(
+        &textureDesc, NULL, &D3DTexture);
+      if (FAILED(hr)) {
+        std::cerr << "Can't create texture for eye " << i << std::endl;
+        return 1;
+      }
+
+      // Fill in the resource view for your render texture buffer here
+      D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc = {};
+      // This must match what was created in the texture to be rendered
+      renderTargetViewDesc.Format = textureDesc.Format;
+      renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+      renderTargetViewDesc.Texture2D.MipSlice = 0;
+
+      // Create the render target view.
+      ID3D11RenderTargetView*
+        renderTargetView = nullptr; //< Pointer to our render target view
+      hr = renderInfo[i].library.D3D11->device->CreateRenderTargetView(
+        D3DTexture, &renderTargetViewDesc, &renderTargetView);
+      if (FAILED(hr)) {
+        std::cerr << "Could not create render target for eye " << i
+          << std::endl;
+        return 2;
+      }
+
+      // Push the filled-in RenderBuffer onto the stack.
+      osvr::renderkit::RenderBufferD3D11* rbD3D =
+        new osvr::renderkit::RenderBufferD3D11;
+      rbD3D->colorBuffer = D3DTexture;
+      rbD3D->colorBufferView = renderTargetView;
+      osvr::renderkit::RenderBuffer rb;
+      rb.D3D11 = rbD3D;
+      renderBuffers.push_back(rb);
+
+      //==================================================================
+      // Create a depth buffer
+
+      // Make the depth/stencil texture.
+      D3D11_TEXTURE2D_DESC textureDescription = {};
+      textureDescription.SampleDesc.Count = 1;
+      textureDescription.SampleDesc.Quality = 0;
+      textureDescription.Usage = D3D11_USAGE_DEFAULT;
+      textureDescription.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+      textureDescription.Width = width;
+      textureDescription.Height = height;
+      textureDescription.MipLevels = 1;
+      textureDescription.ArraySize = 1;
+      textureDescription.CPUAccessFlags = 0;
+      textureDescription.MiscFlags = 0;
+      /// @todo Make this a parameter
+      textureDescription.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+      ID3D11Texture2D* depthStencilBuffer;
+      hr = renderInfo[i].library.D3D11->device->CreateTexture2D(
+        &textureDescription, nullptr, &depthStencilBuffer);
+      if (FAILED(hr)) {
+        std::cerr << "Could not create depth/stencil texture for eye " << i
+          << std::endl;
+        return 3;
+      }
+      depthStencilTextures.push_back(depthStencilBuffer);
+
+      // Create the depth/stencil view description
+      D3D11_DEPTH_STENCIL_VIEW_DESC depthStencilViewDescription = {};
+      depthStencilViewDescription.Format = textureDescription.Format;
+      depthStencilViewDescription.ViewDimension =
+        D3D11_DSV_DIMENSION_TEXTURE2D;
+      depthStencilViewDescription.Texture2D.MipSlice = 0;
+
+      ID3D11DepthStencilView* depthStencilView;
+      hr = renderInfo[i].library.D3D11->device->CreateDepthStencilView(
+        depthStencilBuffer, &depthStencilViewDescription,
+        &depthStencilView);
+      if (FAILED(hr)) {
+        std::cerr << "Could not create depth/stencil view for eye " << i
+          << std::endl;
+        return 4;
+      }
+      depthStencilViews.push_back(depthStencilView);
+    }
+
+    // Create depth stencil state.
+    // Describe how depth and stencil tests should be performed.
+    D3D11_DEPTH_STENCIL_DESC depthStencilDescription = {};
+
+    depthStencilDescription.DepthEnable = true;
+    depthStencilDescription.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
+    depthStencilDescription.DepthFunc = D3D11_COMPARISON_LESS;
+
+    depthStencilDescription.StencilEnable = true;
+    depthStencilDescription.StencilReadMask = 0xFF;
+    depthStencilDescription.StencilWriteMask = 0xFF;
+
+    // Front-facing stencil operations
+    depthStencilDescription.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+    depthStencilDescription.FrontFace.StencilDepthFailOp =
+      D3D11_STENCIL_OP_INCR;
+    depthStencilDescription.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+    depthStencilDescription.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+
+    // Back-facing stencil operations
+    depthStencilDescription.BackFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+    depthStencilDescription.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_DECR;
+    depthStencilDescription.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+    depthStencilDescription.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+
+    hr = renderInfo[0].library.D3D11->device->CreateDepthStencilState(
+      &depthStencilDescription, &depthStencilState);
+    if (FAILED(hr)) {
+      std::cerr << "Could not create depth/stencil state" << std::endl;
+      return 5;
+    }
+
+    // Register our constructed buffers so that we can use them for
+    // presentation.
+    if (!render->RegisterRenderBuffers(renderBuffers)) {
+      std::cerr << "RegisterRenderBuffers() returned false, cannot continue"
+        << std::endl;
+      return 6;
+    }
+
+    // Frame timing
+    size_t countFrames = 0;
+    struct timeval startFrames;
+    vrpn_gettimeofday(&startFrames, nullptr);
+
+    // Continue rendering until it is time to quit.
+    struct timeval start;
+    vrpn_gettimeofday(&start, nullptr);
+    while (!quit) {
+        // Update the context so we get our callbacks called and
+        // update tracker state.
+        context.update();
+
+        // Figure out how much to spin the world based on time since we
+        // started. Then adjust the room-to-world rotation to match.
+        // NOTE: This is better debugging demo than a stand-inside demo;
+        // it will tend you make you uncomfortable.
+        struct timeval now;
+        vrpn_gettimeofday(&now, nullptr);
+        double rads =
+            spinRateRadiansPerSecond * vrpn_TimevalDurationSeconds(now, start);
+        q_type spinQ;
+        q_from_axis_angle(spinQ, 0, 1, 0, rads);
+        OSVR_Quaternion spinQuat;
+        osvrQuatSetX(&spinQuat, spinQ[Q_X]);
+        osvrQuatSetY(&spinQuat, spinQ[Q_Y]);
+        osvrQuatSetZ(&spinQuat, spinQ[Q_Z]);
+        osvrQuatSetW(&spinQuat, spinQ[Q_W]);
+        OSVR_PoseState spin;
+        spin.translation = {};
+        spin.rotation = spinQuat;
+        osvr::renderkit::RenderManager::RenderParams params;
+        params.worldFromRoomAppend = &spin;
+
+        // Render into each buffer using the specified information.
+        std::vector<osvr::renderkit::RenderInfo> renderInfo =
+          render->GetRenderInfo(params);
+        for (size_t i = 0; i < renderInfo.size(); i++) {
+            renderInfo[i].library.D3D11->context->OMSetDepthStencilState(
+                depthStencilState, 1);
+            RenderView(renderInfo[i],
+                       renderBuffers[i].D3D11->colorBufferView,
+                       depthStencilViews[i]);
+        }
+
+        // Send the rendered results to the screen
+        if (!render->PresentRenderBuffers(renderBuffers, renderInfo, params)) {
+            std::cerr << "PresentRenderBuffers() returned false, maybe because "
+                         "it was asked to quit"
+                      << std::endl;
+            quit = true;
+        }
+
+        // Print timing info
+        struct timeval nowFrames;
+        vrpn_gettimeofday(&nowFrames, nullptr);
+        double duration = vrpn_TimevalDurationSeconds(nowFrames, startFrames);
+        countFrames++;
+        if (duration >= 2.0) {
+            std::cout << "Rendering at " << countFrames / duration << " fps"
+                      << std::endl;
+            startFrames = nowFrames;
+            countFrames = 0;
+
+            std::cout << "Creating new RenderManager" << std::endl;
+            osvr::renderkit::RenderManager* render = GetNewRenderManager(context,
+              library);
+            if (render == nullptr) {
+              std::cerr << "Could not construct new RenderManager" << std::endl;
+              return 200;
+            }
+
+            // Register our constructed buffers so that we can use them for
+            // presentation.
+            if (!render->RegisterRenderBuffers(renderBuffers)) {
+              std::cerr << "RegisterRenderBuffers() returned false, cannot continue"
+                << std::endl;
+              return 201;
+            }
+        }
+    }
+
+    // Clean up after ourselves.
+    // @todo
+
+    // Close the Renderer interface cleanly.
+    delete render;
+
+    return 0;
+}

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2767,7 +2767,7 @@ namespace renderkit {
 #endif
         } else if (p.m_renderLibrary == "OpenGL") {
             if (p.m_directMode) {
-// nVidia DirectMode is currently only implemented under Direct3D11,
+// DirectMode is currently only implemented under Direct3D11,
 // so we wrap this with an OpenGL renderer.
 #if defined(RM_USE_NVIDIA_DIRECT_D3D11_OPENGL) && !defined(RM_USE_OPENGLES20)
                 // Set the parameters on the harnessed renderer to not apply the

--- a/osvr/RenderKit/RenderManagerD3D.cpp
+++ b/osvr/RenderKit/RenderManagerD3D.cpp
@@ -1,10 +1,10 @@
 /** @file
-@brief Source file implementing nVidia-based OSVR direct-to-device rendering
-interface
+@brief Source file implementing D3D rendering to a window.
 
 @date 2015
 
 @author
+Russ Taylor <russ@sensics.com>
 Sensics, Inc.
 <http://sensics.com/osvr>
 */
@@ -25,6 +25,7 @@ Sensics, Inc.
 
 #include "RenderManagerD3D.h"
 #include "GraphicsLibraryD3D11.h"
+#include "RenderManagerSDLInitQuit.h"
 #include <iostream>
 #include "SDL_syswm.h"
 #include <d3d11.h>
@@ -36,7 +37,7 @@ namespace renderkit {
     RenderManagerD3D11::RenderManagerD3D11(
         OSVR_ClientContext context,
         ConstructorParameters p)
-        : RenderManagerD3D11Base(context, p) {}
+        : RenderManagerD3D11Base(context, p) { }
 
     RenderManagerD3D11::~RenderManagerD3D11() {
         for (size_t i = 0; i < m_displays.size(); i++) {
@@ -48,7 +49,6 @@ namespace renderkit {
             /// @todo Clean up anything else we need to
             m_displayOpen = false;
         }
-        SDL_Quit();
     }
 
     RenderManager::OpenResults RenderManagerD3D11::OpenDisplay(void) {
@@ -75,7 +75,7 @@ namespace renderkit {
         // Use SDL to get us a window.
 
         // Initialize the SDL video subsystem.
-        if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
+        if (!SDLInitQuit()) {
             std::cerr << "RenderManagerD3D11::openD3D11Context: Could not "
                          "initialize SDL"
                       << std::endl;

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -35,6 +35,7 @@ Sensics, Inc.
 #endif
 #include "RenderManagerOpenGL.h"
 #include "GraphicsLibraryOpenGL.h"
+#include "RenderManagerSDLInitQuit.h"
 #include <iostream>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -174,7 +175,6 @@ namespace renderkit {
         }
         delete m_buffers.OpenGL;
         delete m_library.OpenGL;
-        SDL_Quit();
     }
 
     bool RenderManagerOpenGL::RenderPathSetup() {
@@ -246,14 +246,11 @@ namespace renderkit {
 
     bool RenderManagerOpenGL::addOpenGLContext(GLContextParams p) {
         // Initialize the SDL video subsystem.
-        if (!m_sdl_initialized) {
-            if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
-                std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not "
-                             "initialize SDL"
-                          << std::endl;
-                return false;
-            }
-            m_sdl_initialized = true;
+        if (!osvr::renderkit::SDLInitQuit()) {
+            std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not "
+                          "initialize SDL"
+                      << std::endl;
+            return false;
         }
 
         // Figure out the flags we want

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -147,7 +147,6 @@ namespace renderkit {
         bool constructRenderBuffers();
 
         // Classes and structures needed to do our rendering.
-        bool m_sdl_initialized = false;
         class DisplayInfo {
           public:
             SDL_Window* m_window = nullptr; //< The window we're rendering into

--- a/osvr/RenderKit/RenderManagerSDLInitQuit.cpp
+++ b/osvr/RenderKit/RenderManagerSDLInitQuit.cpp
@@ -1,0 +1,77 @@
+/** @file
+@brief Source file implementing SDL Init/Quit call as a singleton across the library
+       and application.
+
+@date 2016
+
+@author
+Russ Taylor <russ@sensics.com>
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <iostream>
+#include <SDL.h>
+#include "RenderManagerSDLInitQuit.h"
+
+namespace osvr {
+namespace renderkit {
+
+  /// Singleton class that calls SDL_Init() when constructed and SDL_Quit()
+  /// when destroyed.  Only one instance of this should be made, and it should
+  /// be assigned to a static std::unique_ptr so that it will be destroyed when
+  /// the program quits.
+  class SDLInitQuitClass {
+  public:
+    SDLInitQuitClass() {
+      if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
+        m_working = false;
+      }
+    }
+
+    ~SDLInitQuitClass() {
+      if (m_working) {
+        //  Oddly enough, when we called SDL_Quit() inside the destructor of a
+        // RenderManager that had constructed it in OpenDisplay(), it did not hang.
+        // But when we call it at program shutdown, it hangs.
+        //   According to one online report, SDL_Quit() can get stuck inside a
+        // call to SDL_DestroyWindow() when
+        // we've already destroyed all of the windows we created, or when we don't
+        // create any windows.  So unfortunately, we can't call it.  Presumably, it
+        // will clean itself up when the program finishes exiting or the DLL completes
+        // its unloading.  If this behavior stops happing in the future, we can
+        // put it back in.
+        //   @todo If this starts working again on all architectures in a future version
+        // of SDL, put it back in.
+        //SDL_Quit();
+      }
+    }
+    bool m_working = true;
+  };
+  static std::unique_ptr<SDLInitQuitClass> myPtr = nullptr;
+
+  bool SDLInitQuit()
+  {
+    if (myPtr == nullptr) {
+      myPtr.reset(new SDLInitQuitClass);
+    }
+    return myPtr->m_working;
+ }
+
+} // namespace renderkit
+} // namespace osvr

--- a/osvr/RenderKit/RenderManagerSDLInitQuit.h
+++ b/osvr/RenderKit/RenderManagerSDLInitQuit.h
@@ -1,0 +1,42 @@
+/** @file
+@brief Header file implementing SDL Init/Quit call as a singleton across the library
+and application.
+
+@date 2016
+
+@author
+Russ Taylor <russ@sensics.com>
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <osvr/RenderKit/Export.h>
+
+namespace osvr {
+namespace renderkit {
+
+  /// This function should be called by any library function or application
+  /// that wants to use SDL, before any SDL function is called.  It handles
+  /// calling SDL_Init() exactly once (no matter how many times this function
+  /// is called) and handles calling SDL_Quit() at program termination (or
+  /// DLL unloading).
+  /// @return Returns true on init success, false on init failure.
+  bool OSVR_RENDERMANAGER_EXPORT SDLInitQuit();
+
+} // namespace renderkit
+} // namespace osvr


### PR DESCRIPTION
This makes SDL_Init() be called only once and prevents SDL_Quit() from being called during RenderManager destruction.  This enables an app to delete and then recreate a RenderManager while running.  Included new test app that deletes and makes new RenderManagers to make sure this is working.