### PR TITLE
Small adjustment to the SolidClearColor/osvrRenderManagerPresentSolid…

### DIFF
--- a/examples/SolidColor.cpp
+++ b/examples/SolidColor.cpp
@@ -170,7 +170,7 @@ int main(int argc, char* argv[]) {
         float c = static_cast<float>(loops - floor(loops));
 
         // Set up the vector of colors to render
-        std::array<float, 3> color = { c, c, c };
+        osvr::renderkit::RGBColorf color = { c, c, c };
 
         // Color each buffer using the specified information.
         if (!render->PresentSolidColor(color)) {

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -113,6 +113,13 @@ namespace renderkit {
         // presented.
     } RenderTimingInfo;
 
+    /// @brief Simple structure for representing a float based RGB color
+    typedef struct {
+        float r;
+        float g;
+        float b;
+    } RGBColorf;
+
     /// @brief Describes the parameters for a display callback handler.
     ///
     /// Description of the type of a Display callback handler.  The user defines
@@ -483,7 +490,7 @@ namespace renderkit {
         ///  @param[in] color The colors to present.
         ///  @return Returns true on success and false on failure.
         bool OSVR_RENDERMANAGER_EXPORT
-          PresentSolidColor(const std::array<float,3> &color);
+          PresentSolidColor(const RGBColorf &color);
 
         ///-------------------------------------------------------------
         /// @brief Get rendering-time statistics
@@ -827,7 +834,7 @@ namespace renderkit {
             bool flipInY = false);
 
         virtual bool PresentSolidColorInternal(
-          const std::array<float, 3> & color);
+          const RGBColorf& color);
 
         virtual bool UpdateDistortionMeshesInternal(
             DistortionMeshType type //< Type of mesh to produce
@@ -1404,7 +1411,7 @@ namespace renderkit {
         /// @param eye[in] The eye to set.
         /// @param color[in] The color to set, RGB, 0-1 for each.
         /// @return True on success, false on failure.
-        virtual bool SolidColorEye(size_t eye, std::array<float, 3> color) = 0;
+        virtual bool SolidColorEye(size_t eye, const RGBColorf &color) = 0;
 
         /// @brief Finalize presentation for a new display
         virtual bool

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -937,7 +937,7 @@ namespace renderkit {
     }
 
     bool RenderManager::PresentSolidColor(
-      const std::array<float, 3> & color) {
+        const RGBColorf &color) {
       // All public methods that use internal state should be guarded
       // by a mutex.
       std::lock_guard<std::mutex> lock(m_mutex);
@@ -946,7 +946,7 @@ namespace renderkit {
     }
 
     bool RenderManager::PresentSolidColorInternal(
-      const std::array<float, 3> & color) {
+        const RGBColorf &color) {
       // Make sure we're doing okay.
       if (!doingOkay()) {
         std::cerr

--- a/osvr/RenderKit/RenderManagerC.cpp
+++ b/osvr/RenderKit/RenderManagerC.cpp
@@ -114,14 +114,16 @@ OSVR_ReturnCode osvrRenderManagerFinishRegisterRenderBuffers(
     return success ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
 }
 
-OSVR_ReturnCode osvrRenderManagerPresentSolidColor(
+OSVR_ReturnCode osvrRenderManagerPresentSolidColorf(
   OSVR_RenderManager renderManager,
-  float rgb[3]) {
+  OSVR_RGB_FLOAT rgb) {
   auto rm = reinterpret_cast<osvr::renderkit::RenderManager*>(renderManager);
 
-  std::array<float, 3> color = { rgb[0], rgb[1], rgb[2] };
+  osvr::renderkit::RGBColorf color;
+  color.r = rgb.r;
+  color.g = rgb.g;
+  color.b = rgb.b;
   bool success = rm->PresentSolidColor(color);
-
   return success ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
 }
 

--- a/osvr/RenderKit/RenderManagerC.h
+++ b/osvr/RenderKit/RenderManagerC.h
@@ -84,6 +84,14 @@ typedef struct OSVR_ViewportDescription {
     double height; //< Last pixel on the right of the viewport in pixels
 } OSVR_ViewportDescription;
 
+// ========================================================================
+// Float representation of an rgb color (without alpha)
+typedef struct OSVR_RGB {
+    float r;
+    float g;
+    float b;
+} OSVR_RGB_FLOAT;
+
 typedef enum {
     OSVR_OPEN_STATUS_FAILURE,
     OSVR_OPEN_STATUS_PARTIAL,
@@ -126,9 +134,9 @@ osvrRenderManagerFinishRegisterRenderBuffers(
     OSVR_CBool appWillNotOverwriteBeforeNewPresent);
 
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
-osvrRenderManagerPresentSolidColor(
+osvrRenderManagerPresentSolidColorf(
     OSVR_RenderManager renderManager,
-    float rgb[3]);
+    OSVR_RGB_FLOAT rgb);
 
 OSVR_EXTERN_C_END
 

--- a/osvr/RenderKit/RenderManagerD3D.cpp
+++ b/osvr/RenderKit/RenderManagerD3D.cpp
@@ -283,12 +283,8 @@ namespace renderkit {
     }
 
     bool RenderManagerD3D11::SolidColorEye(
-      size_t eye, std::array<float, 3> color) {
-      FLOAT colorRGBA[4];
-      for (size_t i = 0; i < color.size(); i++) {
-        colorRGBA[i] = color[i];
-      }
-      colorRGBA[4] = 1;
+        size_t eye, const RGBColorf &color) {
+      FLOAT colorRGBA[4] = { color.r, color.g, color.b, 1 };
       size_t d = GetDisplayUsedByEye(eye);
       m_D3D11Context->ClearRenderTargetView(
         m_displays[d].m_renderTargetView,

--- a/osvr/RenderKit/RenderManagerD3D.h
+++ b/osvr/RenderKit/RenderManagerD3D.h
@@ -69,7 +69,7 @@ namespace renderkit {
         bool PresentDisplayFinalize(size_t display) override;
         bool PresentFrameFinalize() override;
 
-        bool SolidColorEye(size_t eye, std::array<float, 3> color) override;
+        bool SolidColorEye(size_t eye, const RGBColorf &color) override;
 
         friend RenderManager OSVR_RENDERMANAGER_EXPORT*
         createRenderManager(OSVR_ClientContext context,

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -417,7 +417,7 @@ namespace osvr {
             bool PresentDisplayFinalize(size_t display) override { return true; }
             bool PresentFrameFinalize() override { return true; }
 
-            bool SolidColorEye(size_t eye, std::array<float, 3> color) override {
+            bool SolidColorEye(size_t eye, const RGBColorf &color) override {
               return mRenderManager->SolidColorEye(eye, color);
             }
 

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.h
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.h
@@ -136,7 +136,7 @@ namespace renderkit {
           const std::vector<OSVR_ViewportDescription>& normalizedCroppingViewports =
           std::vector<OSVR_ViewportDescription>(),
           bool flipInY = false) override;
-        bool SolidColorEye(size_t eye, std::array<float, 3> color) override {
+        bool SolidColorEye(size_t eye, const RGBColorf &color) override {
           return m_D3D11Renderer->SolidColorEye(eye, color);
         }
 

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -1009,7 +1009,7 @@ namespace renderkit {
     }
 
     bool RenderManagerOpenGL::SolidColorEye(
-          size_t eye, std::array<float, 3> color) {
+          size_t eye, const RGBColorf &color) {
 
       // Construct the OpenGL viewport based on which eye this is.
       OSVR_ViewportDescription viewportDesc;
@@ -1034,7 +1034,7 @@ namespace renderkit {
       }
 
       // Clear to the specified color
-      glClearColor(color[0], color[1], color[2], 1);
+      glClearColor(color.r, color.g, color.b, 1);
       glClear(GL_COLOR_BUFFER_BIT);
 
       return true;

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -223,7 +223,7 @@ namespace renderkit {
         bool PresentFrameInitialize() override { return true; }
         bool PresentDisplayInitialize(size_t display) override;
         bool PresentEye(PresentEyeParameters params) override;
-        bool SolidColorEye(size_t eye, std::array<float, 3> color) override;
+        bool SolidColorEye(size_t eye, const RGBColorf &color) override;
         bool PresentDisplayFinalize(size_t display) override;
         bool PresentFrameFinalize() override;
 


### PR DESCRIPTION
…Color APIs to use structs instead of arrays to represent the color. This makes managed-native bindings easier to write.