### PR TITLE
Render info c api update

### DIFF
--- a/osvr/RenderKit/RenderManagerC.cpp
+++ b/osvr/RenderKit/RenderManagerC.cpp
@@ -127,3 +127,43 @@ OSVR_ReturnCode osvrRenderManagerPresentSolidColorf(
   return success ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
 }
 
+OSVR_ReturnCode osvrRenderManagerGetRenderInfoCollection(
+    OSVR_RenderManager renderManager,
+    OSVR_RenderParams renderParams,
+    OSVR_RenderInfoCollection* renderInfoCollectionOut) {
+
+    if (renderManager && renderInfoCollectionOut) {
+        osvr::renderkit::RenderManager::RenderParams _renderParams;
+        ConvertRenderParams(renderParams, _renderParams);
+        auto rm = reinterpret_cast<osvr::renderkit::RenderManager*>(renderManager);
+        RenderManagerRenderInfoCollection* ret = new RenderManagerRenderInfoCollection();
+        ret->renderInfo = rm->GetRenderInfo(_renderParams);
+        (*renderInfoCollectionOut) =
+            reinterpret_cast<OSVR_RenderInfoCollection*>(ret);
+        return OSVR_RETURN_SUCCESS;
+    }
+    return OSVR_RETURN_FAILURE;
+}
+
+OSVR_ReturnCode osvrRenderManagerReleaseRenderInfoCollection(
+    OSVR_RenderInfoCollection renderInfoCollection) {
+
+    if (renderInfoCollection) {
+        auto ri = reinterpret_cast<RenderManagerRenderInfoCollection*>(renderInfoCollection);
+        delete ri;
+        return OSVR_RETURN_SUCCESS;
+    }
+    return OSVR_RETURN_FAILURE;
+}
+
+OSVR_ReturnCode osvrRenderManagerGetNumRenderInfoInCollection(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount* countOut) {
+
+    if (renderInfoCollection && countOut) {
+        auto ri = reinterpret_cast<RenderManagerRenderInfoCollection*>(renderInfoCollection);
+        (*countOut) = ri->renderInfo.size();
+        return OSVR_RETURN_SUCCESS;
+    }
+    return OSVR_RETURN_FAILURE;
+}

--- a/osvr/RenderKit/RenderManagerC.h
+++ b/osvr/RenderKit/RenderManagerC.h
@@ -53,6 +53,7 @@ OSVR_EXTERN_C_BEGIN
 typedef void* OSVR_RenderManager;
 typedef void* OSVR_RenderManagerPresentState;
 typedef void* OSVR_RenderManagerRegisterBufferState;
+typedef void* OSVR_RenderInfoCollection;
 typedef size_t OSVR_RenderInfoCount;
 
 // @todo could we use this for the C++ API as well?
@@ -103,6 +104,7 @@ typedef enum {
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrDestroyRenderManager(OSVR_RenderManager renderManager);
 
+/// DEPRECATED - use the RenderInfoCollection API for your specific graphics API instead.
 /// This function reads all of the rendering parameters from the
 /// underlying RenderManager.  It caches this information locally
 /// until the next call, and returns the number that it has cached.
@@ -160,6 +162,21 @@ OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrRenderManagerPresentSolidColorf(
     OSVR_RenderManager renderManager,
     OSVR_RGB_FLOAT rgb);
+
+OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
+osvrRenderManagerGetRenderInfoCollection(
+    OSVR_RenderManager renderManager,
+    OSVR_RenderParams renderParams,
+    OSVR_RenderInfoCollection* renderInfoCollectionOut);
+
+OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
+osvrRenderManagerReleaseRenderInfoCollection(
+    OSVR_RenderInfoCollection renderInfoCollection);
+
+OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
+osvrRenderManagerGetNumRenderInfoInCollection(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount* countOut);
 
 OSVR_EXTERN_C_END
 

--- a/osvr/RenderKit/RenderManagerC.h
+++ b/osvr/RenderKit/RenderManagerC.h
@@ -163,16 +163,23 @@ osvrRenderManagerPresentSolidColorf(
     OSVR_RenderManager renderManager,
     OSVR_RGB_FLOAT rgb);
 
+/// This function gets all of the RenderInfo collection in one atomic call.
+/// Use osvrRenderManagerGetNumRenderInfoInCollection to get the size of the
+/// collection, and API-specific methods to get a given render info for that
+/// graphics API. Finally, use osvrRenderManagerReleaseRenderInfoCollection
+/// when you're done.
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrRenderManagerGetRenderInfoCollection(
     OSVR_RenderManager renderManager,
     OSVR_RenderParams renderParams,
     OSVR_RenderInfoCollection* renderInfoCollectionOut);
 
+/// Releases the OSVR_RenderInfoCollection.
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrRenderManagerReleaseRenderInfoCollection(
     OSVR_RenderInfoCollection renderInfoCollection);
 
+/// Get the size of the OSVR_RenderInfoCollection.
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrRenderManagerGetNumRenderInfoInCollection(
     OSVR_RenderInfoCollection renderInfoCollection,

--- a/osvr/RenderKit/RenderManagerD3D11C.cpp
+++ b/osvr/RenderKit/RenderManagerD3D11C.cpp
@@ -147,3 +147,11 @@ OSVR_ReturnCode osvrRenderManagerRegisterRenderBufferD3D11(
     return osvrRenderManagerRegisterRenderBufferImpl(registerBufferState,
                                                      renderBuffer);
 }
+
+OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionD3D11(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount index,
+    OSVR_RenderInfoD3D11* renderInfoOut) {
+    return osvrRenderManagerGetRenderInfoFromCollectionImpl(
+        renderInfoCollection, index, renderInfoOut);
+}

--- a/osvr/RenderKit/RenderManagerD3D11C.h
+++ b/osvr/RenderKit/RenderManagerD3D11C.h
@@ -94,6 +94,7 @@ osvrRenderManagerRegisterRenderBufferD3D11(
     OSVR_RenderManagerRegisterBufferState registerBufferState,
     OSVR_RenderBufferD3D11 renderBuffer);
 
+/// Gets an OSVR_RenderInfoD3D11 from a given OSVR_RenderInfoCollection.
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionD3D11(
     OSVR_RenderInfoCollection renderInfoCollection,
     OSVR_RenderInfoCount index,

--- a/osvr/RenderKit/RenderManagerD3D11C.h
+++ b/osvr/RenderKit/RenderManagerD3D11C.h
@@ -69,6 +69,7 @@ OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrCreateRenderManagerD3D11(
     OSVR_RenderManager* renderManagerOut,
     OSVR_RenderManagerD3D11* renderManagerD3D11Out);
 
+/**  DEPRECATED, use the collection render info API instead. */
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrRenderManagerGetRenderInfoD3D11(
     OSVR_RenderManagerD3D11 renderManager, OSVR_RenderInfoCount renderInfoIndex,
     OSVR_RenderParams renderParams, OSVR_RenderInfoD3D11* renderInfoOut);
@@ -92,6 +93,11 @@ OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrRenderManagerRegisterRenderBufferD3D11(
     OSVR_RenderManagerRegisterBufferState registerBufferState,
     OSVR_RenderBufferD3D11 renderBuffer);
+
+OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionD3D11(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount index,
+    OSVR_RenderInfoD3D11* renderInfoOut);
 
 OSVR_EXTERN_C_END
 

--- a/osvr/RenderKit/RenderManagerImpl.h
+++ b/osvr/RenderKit/RenderManagerImpl.h
@@ -27,6 +27,7 @@
 
 // Internal Includes
 #include <osvr/RenderKit/RenderManagerC.h>
+#include <osvr/RenderKit/RenderManager.h>
 
 // Library/third-party includes
 // - none
@@ -45,6 +46,10 @@ typedef struct RenderManagerPresentState {
 typedef struct RenderManagerRegisterBufferState {
     std::vector<osvr::renderkit::RenderBuffer> renderBuffers;
 } RenderManagerRegisterBufferState;
+
+typedef struct RenderManagerRenderInfoCollection {
+    std::vector<osvr::renderkit::RenderInfo> renderInfo;
+} RenderManagerRenderInfoCollection;
 
 inline void
 ConvertViewport(const OSVR_ViewportDescription& viewport,
@@ -192,6 +197,7 @@ template <class OSVR_RenderBufferType>
 OSVR_ReturnCode osvrRenderManagerRegisterRenderBufferImpl(
     OSVR_RenderManagerRegisterBufferState registerBufferState,
     OSVR_RenderBufferType renderBuffer) {
+
     auto state = reinterpret_cast<RenderManagerRegisterBufferState*>(
         registerBufferState);
     osvr::renderkit::RenderBuffer newRenderBuffer;
@@ -199,5 +205,20 @@ OSVR_ReturnCode osvrRenderManagerRegisterRenderBufferImpl(
     state->renderBuffers.push_back(newRenderBuffer);
     return OSVR_RETURN_SUCCESS;
 }
+
+template <class OSVR_RenderInfoType>
+OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionImpl(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount index,
+    OSVR_RenderInfoType* renderInfoOut) {
+
+    auto ri = reinterpret_cast<RenderManagerRenderInfoCollection*>(renderInfoCollection);
+    if (renderInfoCollection && index >= 0 && index < ri->renderInfo.size() && renderInfoOut) {
+        ConvertRenderInfo(ri->renderInfo[index], *renderInfoOut);
+        return OSVR_RETURN_SUCCESS;
+    }
+    return OSVR_RETURN_FAILURE;
+}
+
 }
 #endif // INCLUDED_RenderManagerImpl_h_GUID_D55DD6BB_14DA_4082_4340_C987D7F22660

--- a/osvr/RenderKit/RenderManagerOpenGLC.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGLC.cpp
@@ -132,3 +132,11 @@ OSVR_ReturnCode osvrRenderManagerRegisterRenderBufferOpenGL(
     return osvrRenderManagerRegisterRenderBufferImpl(registerBufferState,
                                                      renderBuffer);
 }
+
+OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionD3D11(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount index,
+    OSVR_RenderInfoOpenGL* renderInfoOut) {
+    return osvrRenderManagerGetRenderInfoFromCollectionImpl(
+        renderInfoCollection, index, renderInfoOut);
+}

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -86,6 +86,11 @@ osvrRenderManagerRegisterRenderBufferOpenGL(
     OSVR_RenderManagerRegisterBufferState registerBufferState,
     OSVR_RenderBufferOpenGL renderBuffer);
 
+OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionOpenGL(
+    OSVR_RenderInfoCollection renderInfoCollection,
+    OSVR_RenderInfoCount index,
+    OSVR_RenderInfoOpenGL* renderInfoOut);
+
 OSVR_EXTERN_C_END
 
 #endif // INCLUDED_RenderManagerOpenGLC_h_GUID_362705F9_1D6B_468E_3532_B813F7AB50C6

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -86,6 +86,7 @@ osvrRenderManagerRegisterRenderBufferOpenGL(
     OSVR_RenderManagerRegisterBufferState registerBufferState,
     OSVR_RenderBufferOpenGL renderBuffer);
 
+/// Gets a given OSVR_RenderInfoOpenGL from an OSVR_RenderInfoCollection.
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode osvrRenderManagerGetRenderInfoFromCollectionOpenGL(
     OSVR_RenderInfoCollection renderInfoCollection,
     OSVR_RenderInfoCount index,


### PR DESCRIPTION
This adds a new C API for getting an `OSVR_RenderInfoCollection` (an opaque type) atomically. This replaces the old API for getting render info, which got the render info collection again every time a given render info was accessed. The old API is still available but marked deprecated.