### PR TITLE
Distortion parsing improvements

### DIFF
--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -52,6 +52,9 @@ inline Json::Value
 getExternalDistortionFile(const char* distortionTypeName, Json::Reader& reader,
                           Json::Value const& distortionObject,
                           const char* externalFileKey) {
+    auto withError = [&] {
+        return Json::Value(Json::nullValue);
+    };
     Json::Value const& externalFile = distortionObject[externalFileKey];
     if ((!externalFile.isNull()) && (externalFile.isString())) {
         // Read a Json value from the external file, then replace the distortion
@@ -61,31 +64,21 @@ getExternalDistortionFile(const char* distortionTypeName, Json::Reader& reader,
         const std::string fn = externalFile.asString();
         std::ifstream fs{fn};
         if (!fs) {
-            std::cerr << "OSVRDisplayConfiguration::parse(): ERROR: Couldn't "
+            std::cerr << "OSVRDisplayConfiguration::parse(): Warning: Couldn't "
                          "open external "
                       << distortionTypeName << " file " << fn << "!\n";
-            throw DisplayConfigurationParseException(
-                "Couldn't open external " + std::string(distortionTypeName) +
-                " file.");
-            /// @todo should we just return a null value here, instead of
-            /// crashing the app?
-            // return Json::Value(Json::nullValue);
+            return withError();
         }
         if (!reader.parse(fs, externalData, false)) {
-            std::cerr << "OSVRDisplayConfiguration::parse(): ERROR: Couldn't "
+            std::cerr << "OSVRDisplayConfiguration::parse(): Warning: Couldn't "
                          "parse external "
                       << distortionTypeName << " file " << fn << "!\n";
             std::cerr << "Errors: " << reader.getFormattedErrorMessages();
-            throw DisplayConfigurationParseException(
-                "Couldn't parse external " + std::string(distortionTypeName) +
-                " file.");
-            /// @todo should we just return a null value here, instead of
-            /// crashing the app?
-            // return Json::Value(Json::nullValue);
+            return withError();
         }
         return externalData["display"]["hmd"]["distortion"];
     }
-    return Json::Value(Json::nullValue);
+    return withError();
 }
 
 /// Given the distortion object of the json config, tries to turn it into a mesh

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -286,6 +286,9 @@ inline void parseDistortionMonoPointMeshes(
                                                      "point distortion mesh "
                                                      "from data provided.");
         }
+        std::cout << "OSVRDisplayConfiguration::parse(): Using "
+                     "distortion method \"mono_point_samples\""
+                  << std::endl;
         mesh = std::move(newMesh);
     }
 }

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -52,6 +52,7 @@ inline void parseDistortionMonoPointMeshes(
     Json::Value const& distortion,
     osvr::renderkit::MonoPointDistortionMeshDescriptions& mesh) {
     Json::Value myDistortion = distortion;
+    Json::Reader reader;
 
     // See if we have the name of a built-in config to parse.  If so, we open it
     // and grab its values to parse, replacing the ones that they sent
@@ -78,7 +79,6 @@ inline void parseDistortionMonoPointMeshes(
                 "Unrecognized built-in mono point value: " + builtInKey);
         }
 
-        Json::Reader reader;
         if (!reader.parse(builtInString, builtInData)) {
             std::cerr << "OSVRDisplayConfiguration::parse(): ERROR: Couldn't "
                          "parse built-in configuration "
@@ -99,7 +99,6 @@ inline void parseDistortionMonoPointMeshes(
         // Read a Json value from the external file, then replace the distortion
         // mesh with that from the file.
         Json::Value externalData;
-        Json::Reader reader;
         std::ifstream fs;
         fs.open(externalFile.asString().c_str(), std::fstream::in);
         if (!fs.is_open()) {
@@ -170,6 +169,7 @@ inline void parseDistortionRGBPointMeshes(
     Json::Value const& distortion,
     osvr::renderkit::RGBPointDistortionMeshDescriptions& mesh) {
     Json::Value myDistortion = distortion;
+    Json::Reader reader;
 
     // See if we have the name of an external file to parse.  If so, we open it
     // and grab its values to parse.  Otherwise, we parse the ones that they
@@ -180,7 +180,6 @@ inline void parseDistortionRGBPointMeshes(
         // Read a Json value from the external file, then replace the distortion
         // mesh with that from the file.
         Json::Value externalData;
-        Json::Reader reader;
         std::ifstream fs;
         fs.open(externalFile.asString().c_str(), std::fstream::in);
         if (!fs.is_open()) {

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -94,6 +94,9 @@ getExternalDistortionFile(const char* distortionTypeName, Json::Reader& reader,
                       << distortionTypeName << " file " << fn << "!\n";
             return withError();
         }
+        std::cout << "OSVRDisplayConfiguration::parse(): Reading and parsing "
+                     "JSON in external "
+                  << distortionTypeName << " file " << fn << std::endl;
         if (!reader.parse(fs, externalData, false)) {
             std::cerr << "OSVRDisplayConfiguration::parse(): Warning: Couldn't "
                          "parse external "
@@ -101,6 +104,10 @@ getExternalDistortionFile(const char* distortionTypeName, Json::Reader& reader,
             std::cerr << "Errors: " << reader.getFormattedErrorMessages();
             return withError();
         }
+
+        std::cout << "OSVRDisplayConfiguration::parse(): File read and JSON "
+                     "parse complete."
+                  << std::endl;
         return ExternalDistortionReturnValue{
             externalData["display"]["hmd"]["distortion"], std::move(fn)};
     }
@@ -115,6 +122,10 @@ getExternalDistortionFile(const char* distortionTypeName, Json::Reader& reader,
 /// little but just return an empty object: carry on and try your next approach.
 inline osvr::renderkit::MonoPointDistortionMeshDescriptions
 jsonToMonoPointMesh(Json::Value const& distortion, const char* dataSource) {
+
+    std::cout << "OSVRDisplayConfiguration::parse(): Processing JSON data into "
+                 "mono point samples description structure."
+              << std::endl;
     osvr::renderkit::MonoPointDistortionMeshDescriptions mesh;
     Json::Value const& eyeArray = distortion["mono_point_samples"];
     auto withError = [&] {
@@ -162,10 +173,10 @@ jsonToMonoPointMesh(Json::Value const& distortion, const char* dataSource) {
         }
         mesh.push_back(eye);
     }
-    std::cout << "OSVRDisplayConfiguration::parse(): Loaded mono point samples "
-                 "data with "
+    std::cout << "OSVRDisplayConfiguration::parse(): Initial processing "
+                 "complete. Loaded mono point samples data with "
               << mesh[0].size() << " and " << mesh[1].size()
-              << " samples per eye.\n";
+              << " samples per eye, respectively.\n";
     return mesh;
 }
 

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -60,19 +60,20 @@ inline void parseDistortionMonoPointMeshes(
     if ((!builtIn.isNull()) && (builtIn.isString())) {
         // Read a Json value from the built-in config, then replace the
         // distortion mesh with that from the file.
+        const std::string builtInKey = builtIn.asString();
         std::string builtInString;
         Json::Value builtInData;
-        if (builtIn.asString() == "OSVR_HDK_13_V1") {
+        if (builtInKey == "OSVR_HDK_13_V1") {
             builtInString = osvr_display_config_built_in_osvr_hdk13_v1;
-        } else if (builtIn.asString() == "OSVR_HDK_13_V2") {
+        } else if (builtInKey == "OSVR_HDK_13_V2") {
             builtInString = osvr_display_config_built_in_osvr_hdk13_v2;
-        } else if (builtIn.asString() == "OSVR_HDK_20_V1") {
-          builtInString = osvr_display_config_built_in_osvr_hdk20_v1;
+        } else if (builtInKey == "OSVR_HDK_20_V1") {
+            builtInString = osvr_display_config_built_in_osvr_hdk20_v1;
         } else {
             std::cerr
                 << "OSVRDisplayConfiguration::parse(): ERROR: Unrecognized "
                    "mono_point_samples_built_in value: "
-                << builtIn.asString() << "!\n";
+                << builtInKey << "!\n";
             throw DisplayConfigurationParseException(
                 "Couldn't open external mono point file.");
         }

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -119,7 +119,7 @@ inline void parseDistortionMonoPointMeshes(
                 "Unrecognized built-in mono point value: " + builtInKey);
         }
 
-        if (!reader.parse(builtInString, builtInData)) {
+        if (!reader.parse(builtInString, builtInData, false)) {
             std::cerr << "OSVRDisplayConfiguration::parse(): ERROR: Couldn't "
                          "parse built-in configuration "
                       << builtIn.asString() << "!\n";

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -56,7 +56,7 @@ inline void parseDistortionMonoPointMeshes(
     // See if we have the name of a built-in config to parse.  If so, we open it
     // and grab its values to parse, replacing the ones that they sent
     // in.
-    const Json::Value builtIn = distortion["mono_point_samples_built_in"];
+    Json::Value const& builtIn = distortion["mono_point_samples_built_in"];
     if ((!builtIn.isNull()) && (builtIn.isString())) {
         // Read a Json value from the built-in config, then replace the
         // distortion mesh with that from the file.

--- a/osvr/RenderKit/osvr_display_configuration.cpp
+++ b/osvr/RenderKit/osvr_display_configuration.cpp
@@ -75,7 +75,7 @@ inline void parseDistortionMonoPointMeshes(
                    "mono_point_samples_built_in value: "
                 << builtInKey << "!\n";
             throw DisplayConfigurationParseException(
-                "Couldn't open external mono point file.");
+                "Unrecognized built-in mono point value: " + builtInKey);
         }
 
         Json::Reader reader;
@@ -85,7 +85,7 @@ inline void parseDistortionMonoPointMeshes(
                       << builtIn.asString() << "!\n";
             std::cerr << "Errors: " << reader.getFormattedErrorMessages();
             throw DisplayConfigurationParseException(
-                "Couldn't parse external mono point file.");
+                "Couldn't parse built-in mono point distortion.");
         }
         myDistortion = builtInData["display"]["hmd"]["distortion"];
     }


### PR DESCRIPTION
These are a collection of improvements to the distortion parsing code.

- some small performance improvements:
  - avoiding deep-copying `Json::Value` when we can take a `const &`
  - only doing things like `Json::Value::toString()` once and saving the result, instead of doing it repeatedly thus converting, creating, and destroying string objects over and over.
  - Passed `false` as the third, optional parameter to the `Json::Reader::parse()` method - `bool collectComments` - since we're not manipulating the json file for general usage and output, we just want the data, so we can tell the parser to totally ignore comments.
- some de-duplication in the loading of external files: it didn't quite meet the general "rule of 3" (generalize code if it will be used 3 times) because it was used only twice, but the code was identical except for the error messages, and this gives us a single point of change if we want to try different ways of loading from file that might be faster than handing the `std::ifstream` to jsoncpp (since apparently this is several times slower - as in, takes non-negligible time - than loading from a string that's already in memory, at least in some cases.).
- Cleanup and clarification of "which distortion mesh gets used" in the mono point samples codepath, which makes it more resilient (if they specify a bad built-in, it will still try to see if they also specified an external file, etc), and which also resulted in fixing almost all of the `@todo make failure a no-op`. Only if all paths fail does the mono point code still throw an exception, because I didn't dig into what would happen if [`parseDistortionMonoPointMeshes`](https://github.com/sensics/OSVR-RenderManager/blob/b6d3aad8d3f37a011f8ffb71990b87bb84025bda/osvr/RenderKit/osvr_display_configuration.cpp#L51) returned with the `mesh` ref/out-param either unchanged or reset (the two ways it could indicate "hey this didn't work").
- Moved from having of bunch of `if`...`else if`... statements for the built-in meshes to having a nice table at the top of the file that the code (in the middle of the file where the ifs used to be) just iterates through now.
- In the "fail gracefully" work, some (likely debug-level) output on what source of distortion actually does get used (as an aid to configuration), and how many points were loaded from the data set (as an aid to development)

```
OSVRDisplayConfiguration::parse(): Using mono point sample distortion.
OSVRDisplayConfiguration::parse(): Loaded mono point samples data with 1411 and 1411 samples per eye.
OSVRDisplayConfiguration::parse(): Using distortion method "mono_point_samples_built_in": "OSVR_HDK_13_V1"
```

- Progress messages were added before and after potentially time-consuming operations (file loading/parsing, structure creation) to help diagnose issues and avoid the perception of a hang.

Tested using the HDK 1.3 built-in meshes, and three external mesh files (the three built-in meshes, extracted out again into files). I didn't actually notice any speed difference between any of them - they all loaded instantaneously for me - so if there is some case where they aren't loading that fast, there should probably be a separate issue opened with more detailed reproduction steps.