### PR TITLE
Use Eigen::Map facility to avoid a use of memcpy.

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -1795,7 +1795,7 @@ namespace renderkit {
 
         /// Translate so that the origin moves to the location of
         /// the lower-left corner.
-        Eigen::Affine3f translate(Eigen::Translation3f(
+        Eigen::Isometry3f translate(Eigen::Translation3f(
             static_cast<float>(normalizedCroppingViewport.left),
             static_cast<float>(normalizedCroppingViewport.lower), 0.0f));
 
@@ -1806,10 +1806,8 @@ namespace renderkit {
             static_cast<float>(normalizedCroppingViewport.height), 1.0f));
 
         /// Compute the full matrix by multiplying the parts.
-        Eigen::Projective3f full = translate * scale;
-
-        // Store the result.
-        memcpy(outMatrix.data, full.matrix().data(), sizeof(outMatrix.data));
+        Eigen::Matrix4f::Map(outMatrix.data) =
+            Eigen::Projective3f(translate * scale).matrix();
 
         return true;
     }


### PR DESCRIPTION
A comment somewhere mentioned wanting to know how to avoid needing to memcpy, and it is in fact possible in nearly all cases, using the `Map` class: the full gory details on how to use persistent variables of `Map<>` type are here https://eigen.tuxfamily.org/dox/group__TutorialMapClass.html However, that's more complex than you typically need to do:  I tend to use it more as in this patch, using the static members of the various vector and matrix types to make a (optimized away) temporary map for assignment or input purposes: note that it can be used on either side of an expression (as input or as a destination for assignment).

These should get you most everywhere you want to go:

- `Eigen::Vector2d::Map(double* or double const *)`
- `Eigen::Vector3d::Map(double* or double const *)`
- `Eigen::Vector4d::Map(double* or double const *)`
- `Eigen::Matrix4d::Map(double* or double const *)` for a 4x4 aka 16 element *column major* matrix (as long as it's 16 contiguous memory locations this will work)
- `Eigen::Matrix<double, 4, 4, Eigen::RowMajor>::Map(double* or double const *)` for a 4x4 aka 16 element *row major* matrix - if you `#include <osvr/Util/EigenExtras.h>`, I have typedefs `osvr::util::RowMatrix44d` and `osvr::util::RowMatrix44f` (and the same for ColMatrix, if you want to be very explicit about it) that you can use instead: `osvr::util::RowMatrix44d::Map(double * or double const *)`
- Same as above except with `f` instead of `d` on the type name and `float` instead of `double` (think other convenience typedefs also exist too, but those are the only ones I usually use. Looks like there's `i` for `int`, at least.)

There is a quickie summary on the quick ref page under "mapping external arrays", including with strides if you have weird memory you want to map: https://eigen.tuxfamily.org/dox/group__QuickRefPage.html 

Anyway, this patch just does one such change. (I didn't have the heart, or the type, to grep for `memcpy` in the entire codebase.)

It also does a single change of a transform type to a more specific one: always choose the narrowest transform type (Isometry < (Affine/AffineCompact - the same except the latter doesn't store the 0,0,0,1 row of the matrix) < Projective) that is valid, so Eigen can minimize the number of computations that it does. Isometry works for everything that is a pose. I don't remember exactly what scaling causes it to become affine instead of just an isometry, but I am pretty sure that some scaling can be done and still stay in the isometry realm. Projective is basically only needed when you know you will have a bottom row that isn't 0,0,0,1. 