### PR TITLE
Adding VRGate HMD to list of DirectMode displays.

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2651,6 +2651,8 @@ namespace renderkit {
             p.addCandidatePNPID("IWR"); // 0xF226
         } else if (p.m_displayConfiguration.getVendor() == "HTC") {
           p.addCandidatePNPID("HVR"); // 0xD222
+        } else if (p.m_displayConfiguration.getVendor() == "VRGate") {
+          p.addCandidatePNPID("VRG"); // 0x475A
         }
         p.m_directModeIndex = -1; // -1 means select based on resolution
 


### PR DESCRIPTION
VRGate have been signed the NDA with OSVR recently, here is the vendor name to PnP-id mapping of our HMD.