### PR TITLE
Add header-dependency tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(osvrRenderManager)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 #-----------------------------------------------------------------------------
 # Local CMake Modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -374,3 +377,11 @@ if (LIQUIDVR_FOUND AND HAVE_AMD_NDA_SUBMODULE)
 
 	install(TARGETS EnableOSVRDirectModeAMD DisableOSVRDirectModeAMD RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
+
+# Tests
+option(BUILD_TESTS "Build tests" ON)
+if(BUILD_TESTS)
+	set(HEADER_BASE "${CMAKE_CURRENT_SOURCE_DIR}/osvr")
+	add_subdirectory(tests)
+endif()
+

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -40,11 +40,13 @@ typedef void* OSVR_RenderManagerOpenGL;
 
 typedef struct OSVR_GraphicsLibraryOpenGL {
     // intentionally left blank
+    int unused;  // C does not allow empty structures
 } OSVR_GraphicsLibraryOpenGL;
 
 typedef struct OSVR_RenderBufferOpenGL {
     // GLuint colorBufferName;
     // GLuint depthStencilBufferName;
+    int unused;  // C does not allow empty structures
 } OSVR_RenderBufferOpenGL;
 
 typedef struct OSVR_RenderInfoOpenGL {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Tests
+#
+
+include(CTest)
+enable_testing()
+
+# Ensure headers include their own dependencies
+add_subdirectory(header_dependencies)
+

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -1,0 +1,86 @@
+#
+# Ensure all headers include all dependencies
+#
+
+set(IGNORED_HEADERS RenderKit/GraphicsLibraryOpenGL.h)
+
+# Special cases
+if (NOT OSVRRM_HAVE_D3D11_SUPPORT)
+	list(APPEND IGNORED_HEADERS
+		RenderKit/GraphicsLibraryD3D11.h
+		RenderKit/RenderManagerD3D.h
+		RenderKit/RenderManagerD3D11ATW.h
+		RenderKit/RenderManagerD3D11C.h
+		RenderKit/RenderManagerD3DBase.h
+		RenderKit/RenderManagerD3DOpenGL.h
+	)
+endif()
+
+# TODO add nvidia and amd header exceptions/dependencies
+
+if (SDL2_FOUND)
+    set(LIBRARIES_RenderKit_RenderManagerSDLInitQuit SDL2::SDL2)
+    set(LIBRARIES_RenderKit_RenderManagerOpenGL SDL2::SDL2)
+else()
+    list(APPEND IGNORED_HEADERS
+        RenderKit/RenderManagerSDLInitQuit.h
+        RenderKit/RenderManagerOpenGL.h
+    )
+endif()
+
+set(COMMON_TEST_LIBRARIES osvrRenderManager)
+
+add_custom_target(header_dependencies)
+
+file(GLOB_RECURSE headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*.h)
+set(test_index 0)
+foreach(HEADER ${headers})
+    # Sample of relevant variables computed here
+    # HEADER: RenderKit/RenderManager.h
+    # symbolname: RenderKit_RenderManager
+
+    # Compute symbolname
+    string(REPLACE ".h" "" symbolname "${HEADER}")
+    string(MAKE_C_IDENTIFIER "${symbolname}" symbolname)
+
+    list(FIND IGNORED_HEADERS "${HEADER}" _index)
+    # If we didn't explicitly ignore this and if we built this target
+    if(${_index} EQUAL -1)
+        #message(STATUS "${HEADER}: '${symbolname}'")
+
+        set(extensions cpp)
+        if (${HEADER} MATCHES "C.h$")
+            # Header required to be C-safe, enforce it!
+            list(APPEND extensions c)
+        endif()
+
+        foreach(extension ${extensions})
+            # Name the test and output file with a number, to dodge Windows path length limits.
+            # Call it header, instead of test, to avoid polluting the 'executable namespace'
+            set(test_name "header_${extension}_${test_index}")
+
+            set(source_file "${CMAKE_CURRENT_SOURCE_DIR}/main.${extension}")
+
+            add_executable(${test_name} "${source_file}")
+            target_compile_definitions(${test_name} PRIVATE HEADER_TO_TEST="${HEADER}")
+            target_include_directories(${test_name}
+                PRIVATE
+                ${BUILDTREE_HEADER_BASE}
+                ${HEADER_BASE})
+
+            set_target_properties(${test_name} PROPERTIES
+                FOLDER "Header dependency tests")
+
+            target_link_libraries(${test_name}
+                PRIVATE
+                ${COMMON_TEST_LIBRARIES}
+                ${LIBRARIES_${symbolname}})
+
+            add_test(NAME ${test_name}_builds COMMAND ${test_name})
+            add_dependencies(header_dependencies ${test_name})
+        endforeach()
+        math(EXPR test_index "${test_index} + 1")
+    endif()
+endforeach()
+
+

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -19,13 +19,12 @@ endif()
 # TODO add nvidia and amd header exceptions/dependencies
 
 if (SDL2_FOUND)
-    set(LIBRARIES_RenderKit_RenderManagerSDLInitQuit SDL2::SDL2)
-    set(LIBRARIES_RenderKit_RenderManagerOpenGL SDL2::SDL2)
+	set(LIBRARIES_RenderKit_RenderManagerSDLInitQuit SDL2::SDL2)
+	set(LIBRARIES_RenderKit_RenderManagerOpenGL SDL2::SDL2)
 else()
-    list(APPEND IGNORED_HEADERS
-        RenderKit/RenderManagerSDLInitQuit.h
-        RenderKit/RenderManagerOpenGL.h
-    )
+	list(APPEND IGNORED_HEADERS
+		RenderKit/RenderManagerSDLInitQuit.h
+		RenderKit/RenderManagerOpenGL.h)
 endif()
 
 set(COMMON_TEST_LIBRARIES osvrRenderManager)
@@ -35,52 +34,51 @@ add_custom_target(header_dependencies)
 file(GLOB_RECURSE headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*.h)
 set(test_index 0)
 foreach(HEADER ${headers})
-    # Sample of relevant variables computed here
-    # HEADER: RenderKit/RenderManager.h
-    # symbolname: RenderKit_RenderManager
+	# Sample of relevant variables computed here
+	# HEADER: RenderKit/RenderManager.h
+	# symbolname: RenderKit_RenderManager
 
-    # Compute symbolname
-    string(REPLACE ".h" "" symbolname "${HEADER}")
-    string(MAKE_C_IDENTIFIER "${symbolname}" symbolname)
+	# Compute symbolname
+	string(REPLACE ".h" "" symbolname "${HEADER}")
+	string(MAKE_C_IDENTIFIER "${symbolname}" symbolname)
 
-    list(FIND IGNORED_HEADERS "${HEADER}" _index)
-    # If we didn't explicitly ignore this and if we built this target
-    if(${_index} EQUAL -1)
-        #message(STATUS "${HEADER}: '${symbolname}'")
+	list(FIND IGNORED_HEADERS "${HEADER}" _index)
+	# If we didn't explicitly ignore this and if we built this target
+	if(${_index} EQUAL -1)
+		#message(STATUS "${HEADER}: '${symbolname}'")
 
-        set(extensions cpp)
-        if (${HEADER} MATCHES "C.h$")
-            # Header required to be C-safe, enforce it!
-            list(APPEND extensions c)
-        endif()
+		set(extensions cpp)
+		if (${HEADER} MATCHES "C.h$")
+			# Header required to be C-safe, enforce it!
+			list(APPEND extensions c)
+		endif()
 
-        foreach(extension ${extensions})
-            # Name the test and output file with a number, to dodge Windows path length limits.
-            # Call it header, instead of test, to avoid polluting the 'executable namespace'
-            set(test_name "header_${extension}_${test_index}")
+		foreach(extension ${extensions})
+			# Name the test and output file with a number, to dodge Windows path length limits.
+			# Call it header, instead of test, to avoid polluting the 'executable namespace'
+			set(test_name "header_${extension}_${test_index}")
 
-            set(source_file "${CMAKE_CURRENT_SOURCE_DIR}/main.${extension}")
+			set(source_file "${CMAKE_CURRENT_SOURCE_DIR}/main.${extension}")
 
-            add_executable(${test_name} "${source_file}")
-            target_compile_definitions(${test_name} PRIVATE HEADER_TO_TEST="${HEADER}")
-            target_include_directories(${test_name}
-                PRIVATE
-                ${BUILDTREE_HEADER_BASE}
-                ${HEADER_BASE})
+			add_executable(${test_name} "${source_file}")
+			target_compile_definitions(${test_name} PRIVATE HEADER_TO_TEST="${HEADER}")
+			target_include_directories(${test_name}
+				PRIVATE
+				${BUILDTREE_HEADER_BASE}
+				${HEADER_BASE})
 
-            set_target_properties(${test_name} PROPERTIES
-                FOLDER "Header dependency tests")
+			set_target_properties(${test_name} PROPERTIES
+				FOLDER "Header dependency tests")
 
-            target_link_libraries(${test_name}
-                PRIVATE
-                ${COMMON_TEST_LIBRARIES}
-                ${LIBRARIES_${symbolname}})
+			target_link_libraries(${test_name}
+				PRIVATE
+				${COMMON_TEST_LIBRARIES}
+				${LIBRARIES_${symbolname}})
 
-            add_test(NAME ${test_name}_builds COMMAND ${test_name})
-            add_dependencies(header_dependencies ${test_name})
-        endforeach()
-        math(EXPR test_index "${test_index} + 1")
-    endif()
+			add_test(NAME ${test_name}_builds COMMAND ${test_name})
+			add_dependencies(header_dependencies ${test_name})
+		endforeach()
+		math(EXPR test_index "${test_index} + 1")
+	endif()
 endforeach()
-
 

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -2,7 +2,20 @@
 # Ensure all headers include all dependencies
 #
 
-set(IGNORED_HEADERS RenderKit/GraphicsLibraryOpenGL.h)
+set(IGNORED_HEADERS
+        RenderKit/GraphicsLibraryOpenGL.h
+        RenderKit/GraphicsLibraryD3D11.h
+        RenderKit/RenderManagerOpenGL.h
+        RenderKit/RenderManagerD3D.h
+        RenderKit/RenderManagerD3D11ATW.h
+        RenderKit/RenderManagerD3DOpenGL.h
+        RenderKit/NDA/OSVR-RenderManager-NVIDIA/RenderManagerNVidiaD3D.h
+        RenderKit/NDA/OSVR-RenderManager-NVIDIA/CheckSuccess.h
+        RenderKit/NDA/OSVR-RenderManager-NVIDIA/NVAPIWrappers.h
+        RenderKit/NDA/OSVR-RenderManager-NVIDIA/NVIDIADriverVersion.h
+        RenderKit/NDA/OSVR-RenderManager-AMD/RenderManagerAMDD3D.h
+        RenderKit/NDA/OSVR-RenderManager-Intel/RenderManagerIntelD3D.h
+)
 
 # Special cases
 if (NOT OSVRRM_HAVE_D3D11_SUPPORT)
@@ -15,8 +28,6 @@ if (NOT OSVRRM_HAVE_D3D11_SUPPORT)
 		RenderKit/RenderManagerD3DOpenGL.h
 	)
 endif()
-
-# TODO add nvidia and amd header exceptions/dependencies
 
 if (SDL2_FOUND)
 	set(LIBRARIES_RenderKit_RenderManagerSDLInitQuit SDL2::SDL2)

--- a/tests/header_dependencies/main.c
+++ b/tests/header_dependencies/main.c
@@ -1,0 +1,7 @@
+
+#include HEADER_TO_TEST
+
+int main(int argc, char** argv)
+{
+    return 0;
+}

--- a/tests/header_dependencies/main.cpp
+++ b/tests/header_dependencies/main.cpp
@@ -1,0 +1,4 @@
+
+#include HEADER_TO_TEST
+
+int main(int argc, char *argv[]) { return 0; }


### PR DESCRIPTION
If `BUILD_TESTS` is enabled in CMake, this will run the same header-dependency tests that we use in OSVR-Core. Each test includes a single header file and builds a no-op program. If the program builds successfully, it means the header includes (directly or indirectly) all its dependencies. If it fails to build, it may be missing a dependency, or have some other program (check the compiler output for details).

Headers from submodules have not been tested yet, so you may encounter errors when building those. If they require libraries or should be ignored entirely, edit the `tests/header_dependencies/CMakeLists.txt` file appropriately.
