### PR TITLE
Fixes a tautological warning

### DIFF
--- a/osvr/RenderKit/RenderManagerImpl.h
+++ b/osvr/RenderKit/RenderManagerImpl.h
@@ -131,7 +131,7 @@ OSVR_ReturnCode osvrRenderManagerGetRenderInfoImpl(
     ConvertRenderParams(renderParams, _renderParams);
     auto rm = reinterpret_cast<osvr::renderkit::RenderManager*>(renderManager);
     auto ri = rm->GetRenderInfo(_renderParams);
-    if (renderInfoIndex > ri.size() || renderInfoIndex < 0) {
+    if (renderInfoIndex > ri.size()) {
         std::cerr << "[OSVR] renderInfoIndex is out of range" << std::endl;
         return OSVR_RETURN_FAILURE;
     }


### PR DESCRIPTION
renderInfoIndex is unsigned, therefore always > 0.