### PR TITLE
Allow using toolkits other than SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endif()
 #-----------------------------------------------------------------------------
 # OpenGL library as a stand-alone renderer not wrapping D3D
 if ( ( (OPENGL_FOUND AND GLEW_FOUND) OR OPENGLES2_FOUND ) AND SDL2_FOUND)
-	list(APPEND RenderManager_SOURCES osvr/RenderKit/RenderManagerOpenGL.cpp osvr/RenderKit/RenderManagerOpenGL.h osvr/RenderKit/RenderManagerOpenGLC.cpp)
+	list(APPEND RenderManager_SOURCES osvr/RenderKit/RenderManagerOpenGL.cpp osvr/RenderKit/RenderManagerOpenGL.h osvr/RenderKit/RenderManagerOpenGLC.cpp osvr/RenderKit/RenderManagerOpenGLSDL.cpp osvr/RenderKit/RenderManagerOpenGLSDL.h osvr/RenderKit/RenderManagerOpenGLCustom.cpp osvr/RenderKit/RenderManagerOpenGLCustom.h)
 	message(STATUS " - OpenGL support: enabled")
 	set(RM_USE_OPENGL TRUE)
 	set(OSVRRM_HAVE_OPENGL_SUPPORT ON)

--- a/examples/RenderManagerOpenGLQt5Example.cpp
+++ b/examples/RenderManagerOpenGLQt5Example.cpp
@@ -1,0 +1,519 @@
+/** @file
+    @brief Example program that uses the OSVR direct-to-display interface
+           and OpenGL to render a scene with low latency.
+
+    @date 2015
+
+    @author
+    Russ Taylor <russ@sensics.com>
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <QtCore/QObject>
+#include <QtCore/QDebug>
+#include <QtCore/QTimer>
+
+#include <QtGui/QOpenGLFunctions_3_2_Compatibility>
+
+#include <QtOpenGL/QGLWidget>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QHBoxLayout>
+
+// Internal Includes
+#include <osvr/ClientKit/Context.h>
+#include <osvr/ClientKit/Interface.h>
+#include <osvr/RenderKit/RenderManager.h>
+
+// Library/third-party includes
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+// Standard includes
+#include <iostream>
+#include <string>
+#include <stdlib.h> // For exit()
+
+// This must come after we include <GL/gl.h> so its pointer types are defined.
+#include <osvr/RenderKit/GraphicsLibraryOpenGL.h>
+#include <osvr/RenderKit/RenderManagerOpenGLC.h>
+
+void myButtonCallback(void* userdata, const OSVR_TimeValue* /*timestamp*/,
+                      const OSVR_ButtonReport* report) {
+    QApplication::instance()->quit();
+}
+
+static GLfloat matspec[4] = {0.5, 0.5, 0.5, 0.0};
+static float red_col[] = {1.0, 0.0, 0.0};
+static float grn_col[] = {0.0, 1.0, 0.0};
+static float blu_col[] = {0.0, 0.0, 1.0};
+static float yel_col[] = {1.0, 1.0, 0.0};
+static float lightblu_col[] = {0.0, 1.0, 1.0};
+static float pur_col[] = {1.0, 0.0, 1.0};
+
+class Qt5ToolkitImpl {
+    OSVR_OpenGLToolkitFunctions toolkit;
+
+    static void createImpl(void* data) {
+    }
+    static void destroyImpl(void* data) {
+        delete ((Qt5ToolkitImpl*)data);
+    }
+    static OSVR_CBool addOpenGLContextImpl(void* data, const OSVR_OpenGLContextParams* p) {
+        return ((Qt5ToolkitImpl*)data)->addOpenGLContext(p);
+    }
+    static OSVR_CBool removeOpenGLContextsImpl(void* data) {
+        return ((Qt5ToolkitImpl*)data)->removeOpenGLContexts();
+    }
+    static OSVR_CBool makeCurrentImpl(void* data, size_t display) {
+        return ((Qt5ToolkitImpl*)data)->makeCurrent(display);
+    }
+    static OSVR_CBool swapBuffersImpl(void* data, size_t display) {
+        return ((Qt5ToolkitImpl*)data)->swapBuffers(display);
+    }
+    static OSVR_CBool setVerticalSyncImpl(void* data, OSVR_CBool verticalSync) {
+        return ((Qt5ToolkitImpl*)data)->setVerticalSync(verticalSync);
+    }
+    static OSVR_CBool handleEventsImpl(void* data) {
+        return ((Qt5ToolkitImpl*)data)->handleEvents();
+    }
+
+    QList<QGLWidget*> glwidgets;
+    QList<QWidget*> dialogs;
+
+  public:
+    Qt5ToolkitImpl() {
+        memset(&toolkit, 0, sizeof(toolkit));
+        toolkit.size = sizeof(toolkit);
+        toolkit.data = this;
+
+        toolkit.create = createImpl;
+        toolkit.destroy = destroyImpl;
+        toolkit.addOpenGLContext = addOpenGLContextImpl;
+        toolkit.removeOpenGLContexts = removeOpenGLContextsImpl;
+        toolkit.makeCurrent = makeCurrentImpl;
+        toolkit.swapBuffers = swapBuffersImpl;
+        toolkit.setVerticalSync = setVerticalSyncImpl;
+        toolkit.handleEvents = handleEventsImpl;
+    }
+
+    ~Qt5ToolkitImpl() {
+    }
+
+    const OSVR_OpenGLToolkitFunctions* getToolkit() const { return &toolkit; }
+
+    bool addOpenGLContext(const OSVR_OpenGLContextParams* p) {
+        //auto dialog = new QDialog();
+        auto dialog = new QWidget();
+
+        /*
+        qDebug() << "Size:" << p.width << p.height;
+        qDebug() << "Pos:" << p.xPos << p.yPos;
+        qDebug() << "Dis:" << p.displayIndex << p.fullScreen;
+        // */
+
+        dialog->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+
+        dialog->setGeometry(p->xPos, p->yPos, p->width, p->height);
+
+        dialog->setWindowTitle(p->windowTitle);
+
+        if (p->fullScreen)
+            dialog->setWindowState(Qt::WindowFullScreen);
+
+        auto layout = new QHBoxLayout(dialog);
+        layout->setMargin(0);
+        layout->setSpacing(0);
+        auto gl = new QGLWidget(nullptr, glwidgets.size() ? glwidgets.at(0) : nullptr);
+        layout->addWidget(gl);
+
+        if (p->visible)
+            dialog->show();
+
+        //qDebug() << dialog->geometry();
+
+        glwidgets.push_back(gl);
+        dialogs.push_back(dialog);
+
+        return true;
+    }
+    bool removeOpenGLContexts() {
+        for (auto dialog : dialogs)
+            dialog->deleteLater();
+        dialogs.clear();
+        glwidgets.clear();
+
+        return true;
+    }
+    bool makeCurrent(size_t display) {
+        glwidgets.at(display)->makeCurrent();
+        return true;
+    }
+    bool swapBuffers(size_t display) {
+        glwidgets.at(display)->swapBuffers();
+        return true;
+    }
+    bool setVerticalSync(bool verticalSync) {
+    }
+    bool handleEvents() {
+    }
+};
+
+class RenderManagerOpenGLQt5Example : public QOpenGLFunctions_3_2_Compatibility {
+  public:
+    bool SetupRendering(osvr::renderkit::GraphicsLibrary library) {
+        // Make sure our pointers are filled in correctly.  The config file selects
+        // the graphics library to use, and may not match our needs.
+        if (library.OpenGL == nullptr) {
+            std::cerr << "SetupRendering: No OpenGL GraphicsLibrary, this "
+                         "should not happen"
+                      << std::endl;
+            return false;
+        }
+
+        osvr::renderkit::GraphicsLibraryOpenGL* glLibrary = library.OpenGL;
+
+        // Turn on depth testing, so we get correct ordering.
+        glEnable(GL_DEPTH_TEST);
+
+        return true;
+    }
+
+    // Render the world from the specified point of view.
+    void RenderView(
+        const osvr::renderkit::RenderInfo& renderInfo, //< Info needed to render
+        GLuint frameBuffer, //< Frame buffer object to bind our buffers to
+        GLuint colorBuffer, //< Color buffer to render into
+        GLuint depthBuffer  //< Depth buffer to render into
+                    ) {
+        // Make sure our pointers are filled in correctly.  The config file selects
+        // the graphics library to use, and may not match our needs.
+        if (renderInfo.library.OpenGL == nullptr) {
+            std::cerr
+                << "RenderView: No OpenGL GraphicsLibrary, this should not happen"
+                << std::endl;
+            return;
+        }
+
+        // Render to our framebuffer
+        glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+
+        // Set color and depth buffers for the frame buffer
+        glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorBuffer, 0);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                  GL_RENDERBUFFER, depthBuffer);
+
+        // Set the list of draw buffers.
+        GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
+        glDrawBuffers(1, DrawBuffers); // "1" is the size of DrawBuffers
+
+        // Always check that our framebuffer is ok
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            std::cerr << "RenderView: Incomplete Framebuffer" << std::endl;
+            return;
+        }
+
+        // Set the viewport to cover our entire render texture.
+        glViewport(0, 0, static_cast<GLsizei>(renderInfo.viewport.width),
+                   static_cast<GLsizei>(renderInfo.viewport.height));
+
+        // Set the OpenGL projection matrix
+        GLdouble projection[16];
+        osvr::renderkit::OSVR_Projection_to_OpenGL(projection,
+                                                   renderInfo.projection);
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        glMultMatrixd(projection);
+
+        /// Put the transform into the OpenGL ModelView matrix
+        GLdouble modelView[16];
+        osvr::renderkit::OSVR_PoseState_to_OpenGL(modelView, renderInfo.pose);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        glMultMatrixd(modelView);
+
+        // Clear the screen to black and clear depth
+        glClearColor(0, 0, 0, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        // =================================================================
+        // This is where we draw our world and hands and any other objects.
+        // We're in World Space.  To find out about where to render objects
+        // in OSVR spaces (like left/right hand space) we need to query the
+        // interface and handle the coordinate tranforms ourselves.
+
+        // Draw a cube with a 5-meter radius as the room we are floating in.
+        draw_cube(5.0);
+    }
+
+    void draw_cube(double radius) {
+        GLfloat matspec[4] = {0.5, 0.5, 0.5, 0.0};
+        glPushMatrix();
+        glScaled(radius, radius, radius);
+        glMaterialfv(GL_FRONT, GL_SPECULAR, matspec);
+        glMaterialf(GL_FRONT, GL_SHININESS, 64.0);
+        glBegin(GL_POLYGON);
+        glColor3fv(lightblu_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, lightblu_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, lightblu_col);
+        glNormal3f(0.0, 0.0, -1.0);
+        glVertex3f(1.0, 1.0, -1.0);
+        glVertex3f(1.0, -1.0, -1.0);
+        glVertex3f(-1.0, -1.0, -1.0);
+        glVertex3f(-1.0, 1.0, -1.0);
+        glEnd();
+        glBegin(GL_POLYGON);
+        glColor3fv(blu_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, blu_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, blu_col);
+        glNormal3f(0.0, 0.0, 1.0);
+        glVertex3f(-1.0, 1.0, 1.0);
+        glVertex3f(-1.0, -1.0, 1.0);
+        glVertex3f(1.0, -1.0, 1.0);
+        glVertex3f(1.0, 1.0, 1.0);
+        glEnd();
+        glBegin(GL_POLYGON);
+        glColor3fv(yel_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, yel_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, yel_col);
+        glNormal3f(0.0, -1.0, 0.0);
+        glVertex3f(1.0, -1.0, 1.0);
+        glVertex3f(-1.0, -1.0, 1.0);
+        glVertex3f(-1.0, -1.0, -1.0);
+        glVertex3f(1.0, -1.0, -1.0);
+        glEnd();
+        glBegin(GL_POLYGON);
+        glColor3fv(grn_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, grn_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, grn_col);
+        glNormal3f(0.0, 1.0, 0.0);
+        glVertex3f(1.0, 1.0, 1.0);
+        glVertex3f(1.0, 1.0, -1.0);
+        glVertex3f(-1.0, 1.0, -1.0);
+        glVertex3f(-1.0, 1.0, 1.0);
+        glEnd();
+        glBegin(GL_POLYGON);
+        glColor3fv(pur_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, pur_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, pur_col);
+        glNormal3f(-1.0, 0.0, 0.0);
+        glVertex3f(-1.0, 1.0, 1.0);
+        glVertex3f(-1.0, 1.0, -1.0);
+        glVertex3f(-1.0, -1.0, -1.0);
+        glVertex3f(-1.0, -1.0, 1.0);
+        glEnd();
+        glBegin(GL_POLYGON);
+        glColor3fv(red_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, red_col);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, red_col);
+        glNormal3f(1.0, 0.0, 0.0);
+        glVertex3f(1.0, -1.0, 1.0);
+        glVertex3f(1.0, -1.0, -1.0);
+        glVertex3f(1.0, 1.0, -1.0);
+        glVertex3f(1.0, 1.0, 1.0);
+        glEnd();
+        glPopMatrix();
+    }
+};
+
+int main(int argc, char* argv[]) {
+    QApplication app(argc, argv);
+
+#if QTCORE_VERSION >= 0x050300
+    // Use desktop OpenGL to make sure that Qt uses the same OpenGL
+    // implementation as RenderKit
+    app.setAttribute(Qt::AA_UseDesktopOpenGL, true);
+#endif
+
+    // Get an OSVR client context to use to access the devices
+    // that we need.
+    osvr::clientkit::ClientContext context(
+        "com.osvr.renderManager.openGLExample");
+
+    // Construct button devices and connect them to a callback
+    // that will set the "quit" variable to true when it is
+    // pressed.  Use button "1" on the left-hand or
+    // right-hand controller.
+    osvr::clientkit::Interface leftButton1 =
+        context.getInterface("/controller/left/1");
+    leftButton1.registerCallback(&myButtonCallback, nullptr);
+
+    osvr::clientkit::Interface rightButton1 =
+        context.getInterface("/controller/right/1");
+    rightButton1.registerCallback(&myButtonCallback, nullptr);
+
+    auto toolkit = new Qt5ToolkitImpl();
+
+    osvr::renderkit::GraphicsLibrary myLibrary;
+    myLibrary.OpenGL = new osvr::renderkit::GraphicsLibraryOpenGL;
+    myLibrary.OpenGL->toolkit = toolkit->getToolkit();
+
+    // Open OpenGL and set up the context for rendering to
+    // an HMD.  Do this using the OSVR RenderManager interface,
+    // which maps to the nVidia or other vendor direct mode
+    // to reduce the latency.
+    osvr::renderkit::RenderManager* render =
+        osvr::renderkit::createRenderManager(context.get(), "OpenGL", myLibrary);
+
+    if ((render == nullptr) || (!render->doingOkay())) {
+        std::cerr << "Could not create RenderManager" << std::endl;
+        return 1;
+    }
+
+    // Open the display and make sure this worked.
+    osvr::renderkit::RenderManager::OpenResults ret = render->OpenDisplay();
+    if (ret.status == osvr::renderkit::RenderManager::OpenStatus::FAILURE) {
+        std::cerr << "Could not open display" << std::endl;
+        delete render;
+        return 2;
+    }
+
+    RenderManagerOpenGLQt5Example example;
+    if (!example.initializeOpenGLFunctions()) {
+        std::cerr << "Could not open initialize OpenGL functions" << std::endl;
+        return 3;
+    }
+
+    // Set up the rendering state we need.
+    if (!example.SetupRendering(ret.library)) {
+        return 4;
+    }
+
+    // Do a call to get the information we need to construct our
+    // color and depth render-to-texture buffers.
+    std::vector<osvr::renderkit::RenderInfo> renderInfo;
+    context.update();
+    renderInfo = render->GetRenderInfo();
+    std::vector<osvr::renderkit::RenderBuffer> colorBuffers;
+    std::vector<GLuint> depthBuffers; //< Depth/stencil buffers to render into
+
+    // Construct the buffers we're going to need for our render-to-texture
+    // code.
+    GLuint frameBuffer; //< Groups a color buffer and a depth buffer
+    example.glGenFramebuffers(1, &frameBuffer);
+    example.glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+
+    for (size_t i = 0; i < renderInfo.size(); i++) {
+
+        // The color buffer for this eye.  We need to put this into
+        // a generic structure for the Present function, but we only need
+        // to fill in the OpenGL portion.
+        //  Note that this must be used to generate a RenderBuffer, not just
+        // a texture, if we want to be able to present it to be rendered
+        // via Direct3D for DirectMode.  This is selected based on the
+        // config file value, so we want to be sure to use the more general
+        // case.
+        //  Note that this texture format must be RGBA and unsigned byte,
+        // so that we can present it to Direct3D for DirectMode
+        GLuint colorBufferName = 0;
+        example.glGenRenderbuffers(1, &colorBufferName);
+        osvr::renderkit::RenderBuffer rb;
+        rb.OpenGL = new osvr::renderkit::RenderBufferOpenGL;
+        rb.OpenGL->colorBufferName = colorBufferName;
+        colorBuffers.push_back(rb);
+
+        // "Bind" the newly created texture : all future texture
+        // functions will modify this texture glActiveTexture(GL_TEXTURE0);
+        example.glBindTexture(GL_TEXTURE_2D, colorBufferName);
+
+        // Determine the appropriate size for the frame buffer to be used for
+        // this eye.
+        int width = static_cast<int>(renderInfo[i].viewport.width);
+        int height = static_cast<int>(renderInfo[i].viewport.height);
+
+        // Give an empty image to OpenGL ( the last "0" means "empty" )
+        example.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+                     GL_UNSIGNED_BYTE, 0);
+
+        // Bilinear filtering
+        example.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        example.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        example.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        example.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+        // The depth buffer
+        GLuint depthrenderbuffer;
+        example.glGenRenderbuffers(1, &depthrenderbuffer);
+        example.glBindRenderbuffer(GL_RENDERBUFFER, depthrenderbuffer);
+        example.glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width,
+                              height);
+        depthBuffers.push_back(depthrenderbuffer);
+    }
+
+    // Register our constructed buffers so that we can use them for
+    // presentation.
+    if (!render->RegisterRenderBuffers(colorBuffers)) {
+        std::cerr << "RegisterRenderBuffers() returned false, cannot continue"
+                  << std::endl;
+        app.quit();
+    }
+
+    QTimer timer;
+    // This callback will be called whenever the Qt main loop is idle
+    // (until app.quit() is called)
+    QObject::connect(&timer, &QTimer::timeout, [&] {
+        // Update the context so we get our callbacks called and
+        // update tracker state.
+        context.update();
+
+        renderInfo = render->GetRenderInfo();
+
+        // Render into each buffer using the specified information.
+        for (size_t i = 0; i < renderInfo.size(); i++) {
+            example.RenderView(renderInfo[i], frameBuffer,
+                       colorBuffers[i].OpenGL->colorBufferName,
+                       depthBuffers[i]);
+        }
+
+        // Send the rendered results to the screen
+        if (!render->PresentRenderBuffers(colorBuffers, renderInfo)) {
+            std::cerr << "PresentRenderBuffers() returned false, maybe because "
+                         "it was asked to quit"
+                      << std::endl;
+            app.quit();
+        }
+    });
+    timer.start();
+
+    int result = app.exec();
+
+    // Clean up after ourselves.
+    example.glDeleteFramebuffers(1, &frameBuffer);
+    for (size_t i = 0; i < renderInfo.size(); i++) {
+        example.glDeleteTextures(1, &colorBuffers[i].OpenGL->colorBufferName);
+        delete colorBuffers[i].OpenGL;
+        example.glDeleteRenderbuffers(1, &depthBuffers[i]);
+    }
+
+    // Close the Renderer interface cleanly.
+    delete render;
+
+    return result;
+}
+
+// Local Variables:
+// mode: c++
+// tab-width: 4
+// c-basic-offset: 4
+// End:

--- a/osvr/RenderKit/GraphicsLibraryOpenGL.h
+++ b/osvr/RenderKit/GraphicsLibraryOpenGL.h
@@ -24,6 +24,9 @@ Russ Taylor <russ@sensics.com>
 
 #pragma once
 
+// Defined in RenderManagerOpenGLC.h
+struct OSVR_OpenGLToolkitFunctions;
+
 namespace osvr {
 namespace renderkit {
 
@@ -53,6 +56,12 @@ namespace renderkit {
         /// sure it is current before calling any RenderManager
         /// method.
         bool shareOpenGLContext = false;
+
+        /// A pointer to a structure containing functions pointers which are
+        /// used for making calls to the toolkit (i.e. creating a window or
+        /// setting the OpenGL context). If toolkit is set to nullptr, it
+        /// defaults to using SDL.
+        const OSVR_OpenGLToolkitFunctions* toolkit = nullptr;
     };
 
     /// @brief Describes a OpenGL textures to be rendered

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -47,7 +47,9 @@ Russ Taylor <russ@sensics.com>
 #endif
 
 #ifdef RM_USE_OPENGL
-#include "RenderManagerOpenGL.h"
+#include "RenderManagerOpenGLCustom.h"
+#include "RenderManagerOpenGLSDL.h"
+#include "GraphicsLibraryOpenGL.h"
 #endif
 
 #include "VendorIdTools.h"
@@ -2222,7 +2224,10 @@ namespace renderkit {
 #endif
             } else {
 #ifdef RM_USE_OPENGL
-              ret.reset(new RenderManagerOpenGL(contextParameter, p));
+              if (p.m_graphicsLibrary.OpenGL && p.m_graphicsLibrary.OpenGL->toolkit)
+                  ret.reset(new RenderManagerOpenGLCustom(contextParameter, p, *p.m_graphicsLibrary.OpenGL->toolkit));
+              else
+                  ret.reset(new RenderManagerOpenGLSDL(contextParameter, p));
 #else
                 std::cerr << "createRenderManager: OpenGL render library not "
                              "compiled in"

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -26,7 +26,7 @@ Sensics, Inc.
 #include <osvr/ClientKit/Context.h>
 #include <osvr/ClientKit/Interface.h>
 #include "RenderManagerD3DBase.h"
-#include "RenderManagerOpenGL.h"
+#include "RenderManagerOpenGLSDL.h"
 #include "GraphicsLibraryD3D11.h"
 
 #include <vector>

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
@@ -39,7 +39,7 @@ namespace renderkit {
         OSVR_ClientContext context,
         ConstructorParameters p,
         std::unique_ptr<RenderManagerD3D11Base>&& D3DToHarness)
-        : RenderManagerOpenGL(context, p),
+        : RenderManagerOpenGLSDL(context, p),
           m_D3D11Renderer(std::move(D3DToHarness)) {
 
         // Initialize all of the variables that don't have to be done in the

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.h
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.h
@@ -26,7 +26,7 @@ Sensics, Inc.
 #include <osvr/ClientKit/Context.h>
 #include <osvr/ClientKit/Interface.h>
 #include "RenderManagerD3DBase.h"
-#include "RenderManagerOpenGL.h"
+#include "RenderManagerOpenGLSDL.h"
 #include "GraphicsLibraryD3D11.h"
 
 #include <vector>
@@ -35,7 +35,7 @@ Sensics, Inc.
 namespace osvr {
 namespace renderkit {
 
-    class RenderManagerD3D11OpenGL : public RenderManagerOpenGL {
+    class RenderManagerD3D11OpenGL : public RenderManagerOpenGLSDL {
       public:
         virtual OSVR_RENDERMANAGER_EXPORT ~RenderManagerD3D11OpenGL();
 

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -35,7 +35,6 @@ Sensics, Inc.
 #endif
 #include "RenderManagerOpenGL.h"
 #include "GraphicsLibraryOpenGL.h"
-#include "RenderManagerSDLInitQuit.h"
 #include "ComputeDistortionMesh.h"
 #include <iostream>
 #include <Eigen/Core>
@@ -146,7 +145,6 @@ namespace renderkit {
         // initialization if they are re-ordered in the header file.
         m_doingOkay = true;
         m_displayOpen = false;
-        m_GLContext = nullptr;
         m_programId = 0;
 
         // Construct the appropriate GraphicsLibrary pointer.
@@ -155,8 +153,6 @@ namespace renderkit {
     }
 
     RenderManagerOpenGL::~RenderManagerOpenGL() {
-        removeOpenGLContexts();
-
         if (m_displayOpen) {
 
             glDeleteFramebuffers(1, &m_frameBuffer);
@@ -245,112 +241,11 @@ namespace renderkit {
         return RegisterRenderBuffersInternal(m_colorBuffers);
     }
 
-    bool RenderManagerOpenGL::addOpenGLContext(GLContextParams p) {
-        // Initialize the SDL video subsystem.
-        if (!osvr::renderkit::SDLInitQuit()) {
-            std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not "
-                          "initialize SDL"
-                      << std::endl;
-            return false;
-        }
-
-        // Figure out the flags we want
-        Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
-        if (p.fullScreen) {
-            //        flags |= SDL_WINDOW_FULLSCREEN | SDL_WINDOW_BORDERLESS;
-            flags |= SDL_WINDOW_BORDERLESS;
-        }
-        if (p.visible) {
-            flags |= SDL_WINDOW_SHOWN;
-        } else {
-            flags |= SDL_WINDOW_HIDDEN;
-        }
-
-        // Set the OpenGL attributes we want before opening the window
-        if (p.numBuffers > 1) {
-            SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-        }
-        SDL_GL_SetAttribute(SDL_GL_RED_SIZE, p.bitsPerPixel);
-        SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, p.bitsPerPixel);
-        SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, p.bitsPerPixel);
-        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, p.bitsPerPixel);
-        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-        SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
-#ifdef __APPLE__
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
-            SDL_GL_CONTEXT_PROFILE_CORE);
-#endif
-
-        // For now, append the display ID to the title.
-        /// @todo Make a different title for each window in the config file
-        char displayId = '0' + static_cast<char>(m_displays.size());
-        std::string windowTitle = m_params.m_windowTitle + displayId;
-
-        // For now, move the X position of the second display to the
-        // right of the entire display for the left one.
-        /// @todo Make the config-file entry a vector and read both
-        /// from it.
-        p.xPos += p.width * static_cast<int>(m_displays.size());
-
-        // If this is not the first display, or if the configuration
-        // includes a graphics library that says to share, we re-use
-        // the existing context.
-        if ((m_displays.size() > 0) ||
-          ((m_params.m_graphicsLibrary.OpenGL != nullptr) &&
-          (m_params.m_graphicsLibrary.OpenGL->shareOpenGLContext == true))) {
-
-          // Share the current context
-          SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
-        } else {
-          // Replace the current context
-          SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 0);
-        }
-
-        // Push back a new window and context.
-        m_displays.push_back(DisplayInfo());
-        m_displays.back().m_window = SDL_CreateWindow(
-            windowTitle.c_str(), p.xPos, p.yPos, p.width, p.height, flags);
-        if (m_displays.back().m_window == nullptr) {
-            std::cerr
-                << "RenderManagerOpenGL::addOpenGLContext: Could not get window"
-                << std::endl;
-            return false;
-        }
-
-        m_GLContext = SDL_GL_CreateContext(m_displays.back().m_window);
-        if (m_GLContext == nullptr) {
-            std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not get "
-                         "OpenGL context"
-                      << std::endl;
-            return false;
-        }
-
-        return true;
-    }
-
-    bool RenderManagerOpenGL::removeOpenGLContexts() {
+    void RenderManagerOpenGL::deleteProgram() {
         if (m_programId != 0) {
             glDeleteProgram(m_programId);
             m_programId = 0;
         }
-        if (m_GLContext) {
-            SDL_GL_DeleteContext(m_GLContext);
-            m_GLContext = 0;
-        }
-        while (m_displays.size() > 0) {
-            if (m_displays.back().m_window == nullptr) {
-                std::cerr << "RenderManagerOpenGL::closeOpenGLContext: No "
-                             "window pointer"
-                          << std::endl;
-                return false;
-            }
-            SDL_DestroyWindow(m_displays.back().m_window);
-            m_displays.back().m_window = nullptr;
-            m_displays.pop_back();
-        }
-        return true;
     }
 
     RenderManager::OpenResults RenderManagerOpenGL::OpenDisplay(void) {
@@ -369,7 +264,7 @@ namespace renderkit {
         /// @todo How to handle window resizing?
 
         //======================================================
-        // Use SDL to get us an OpenGL context.
+        // Get an OpenGL context.
         GLContextParams p;
         p.windowTitle = m_params.m_windowTitle;
         p.fullScreen = m_params.m_windowFullScreen;
@@ -424,19 +319,7 @@ namespace renderkit {
 
         //======================================================
         // Set vertical sync behavior.
-        if (m_params.m_verticalSync) {
-            if (SDL_GL_SetSwapInterval(1) != 0) {
-                std::cerr << "RenderManagerOpenGL::OpenDisplay: Warning: Could "
-                             "not set vertical retrace on"
-                          << std::endl;
-            }
-        } else {
-            if (SDL_GL_SetSwapInterval(0) != 0) {
-                std::cerr << "RenderManagerOpenGL::OpenDisplay: Warning: Could "
-                             "not set vertical retrace off"
-                          << std::endl;
-            }
-        }
+        setVerticalSync(m_params.m_verticalSync);
 
         checkForGLError("RenderManagerOpenGL::OpenDisplay after vsync setting");
 
@@ -533,7 +416,9 @@ namespace renderkit {
         checkForGLError("RenderManagerOpenGL::RenderDisplayInitialize start");
 
         // Make our OpenGL context current
-        SDL_GL_MakeCurrent(m_displays[display].m_window, m_GLContext);
+        if (!makeCurrent(display)) {
+            return false;
+        }
         checkForGLError("RenderManagerOpenGL::RenderDisplayInitialize end");
         return true;
     }
@@ -776,7 +661,9 @@ namespace renderkit {
           "RenderManagerOpenGL::PresentDisplayInitialize: start");
 
         // Make our OpenGL context current
-        SDL_GL_MakeCurrent(m_displays[display].m_window, m_GLContext);
+        if (!makeCurrent(display)) {
+            return false;
+        }
         checkForGLError(
           "RenderManagerOpenGL::PresentDisplayInitialize: after making GL current");
         return true;
@@ -787,19 +674,15 @@ namespace renderkit {
             return false;
         }
 
-        SDL_GL_SwapWindow(m_displays[display].m_window);
+        if (!swapBuffers(display)) {
+            return false;
+        }
         return true;
     }
 
     bool RenderManagerOpenGL::PresentFrameFinalize() {
-        // Let SDL handle any system events that it needs to.
-        SDL_Event e;
-        while (SDL_PollEvent(&e)) {
-            // If SDL has been given a quit event, what should we do?
-            // We return false to let the app know that something went wrong.
-            if (e.window.event == SDL_WINDOWEVENT_CLOSE) {
-                return false;
-            }
+        if (!handleEvents()) {
+            return false;
         }
 
         return true;

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -35,7 +35,6 @@ Sensics, Inc.
 
 #ifdef RM_USE_OPENGLES20
   // @todo This presumes we're compiling on Android.
-  #include <SDL.h>
   #include <GLES2/gl2.h>
   #include <GLES2/gl2ext.h>
 
@@ -68,8 +67,6 @@ Sensics, Inc.
   #else
     #include <GL/gl.h>
   #endif
-  #include <SDL.h>
-  #include <SDL_opengl.h>
 #endif
 
 #include <stdlib.h>
@@ -135,8 +132,23 @@ namespace renderkit {
                 visible = true;
             }
         };
-        bool addOpenGLContext(GLContextParams p);
-        bool removeOpenGLContexts();
+        virtual bool addOpenGLContext(GLContextParams p) = 0;
+        virtual bool removeOpenGLContexts() = 0;
+
+        /// Make the context for display the current context.
+        virtual bool makeCurrent(size_t display) = 0;
+
+        /// Update window after rendering.
+        virtual bool swapBuffers(size_t display) = 0;
+
+        /// Set vertical sync behavior.
+        virtual bool setVerticalSync(bool verticalSync) = 0;
+
+        /// Set vertical sync behavior.
+        virtual bool handleEvents() = 0;
+
+        /// Delete m_programId in destructor.
+        void deleteProgram();
 
         /// Construct the buffers we're going to use in Render() mode, which
         /// we use to actually use the Presentation mode.  This gives us the
@@ -145,16 +157,6 @@ namespace renderkit {
         /// size we need for Asychronous Time Warp and distortion, and keeps
         /// them from being in the same window and so bleeding together.
         bool constructRenderBuffers();
-
-        // Classes and structures needed to do our rendering.
-        class DisplayInfo {
-          public:
-            SDL_Window* m_window = nullptr; //< The window we're rendering into
-        };
-        std::vector<DisplayInfo> m_displays;
-
-        SDL_GLContext
-            m_GLContext; //< The context we use to render to all displays
 
         // Special vertex/fragment shader information for our shader that
         // handles

--- a/osvr/RenderKit/RenderManagerOpenGLC.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGLC.cpp
@@ -27,6 +27,7 @@
 #include <osvr/RenderKit/RenderManager.h>
 #include <osvr/RenderKit/RenderManagerImpl.h>
 #include <osvr/RenderKit/RenderManagerOpenGL.h>
+#include <osvr/RenderKit/GraphicsLibraryOpenGL.h>
 
 // Library/third-party includes
 // - none
@@ -41,12 +42,12 @@ ConvertGraphicsLibrary(const OSVR_GraphicsLibraryOpenGL& graphicsLibrary,
   // place to put them.  Otherwise, we leave the device with its
   // default NULL pointer so that it will not think the contents
   // are valid.
-  //if (graphicsLibrary.device != nullptr ||
-  //    graphicsLibrary.context != nullptr) {
-    // osvr::renderkit::GraphicsLibraryOpenGL *glogl = new
-    // osvr::renderkit::GraphicsLibraryOpenGL();
-    // graphicsLibraryOut.OpenGL = glogl;
-  //}
+  if (graphicsLibrary.toolkit != nullptr) {
+    osvr::renderkit::GraphicsLibraryOpenGL *glogl = new
+      osvr::renderkit::GraphicsLibraryOpenGL();
+    glogl->toolkit = graphicsLibrary.toolkit;
+    graphicsLibraryOut.OpenGL = glogl;
+  }
 }
 
 inline void

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -38,8 +38,41 @@ OSVR_EXTERN_C_BEGIN
 
 typedef void* OSVR_RenderManagerOpenGL;
 
+typedef struct OSVR_OpenGLContextParams {
+    const char* windowTitle;
+    int displayIndex;
+    OSVR_CBool fullScreen;
+    int width;
+    int height;
+    int xPos;
+    int yPos;
+    int bitsPerPixel;
+    unsigned numBuffers;
+    OSVR_CBool visible;
+} OSVR_OpenGLContextParams;
+
+typedef struct OSVR_OpenGLToolkitFunctions {
+    // Should be set to sizeof(OSVR_OpenGLToolkitFunctions) to allow the library
+    // to detect when the client was compiled against an older version which has
+    // fewer members in this struct.
+    size_t size;
+
+    // Pointer which will be passed to all the functions
+    void* data;
+
+    // Functions implementing the toolkit functionality
+    void (*create)(void* data);
+    void (*destroy)(void* data);
+    OSVR_CBool (*addOpenGLContext)(void* data, const OSVR_OpenGLContextParams* p);
+    OSVR_CBool (*removeOpenGLContexts)(void* data);
+    OSVR_CBool (*makeCurrent)(void* data, size_t display);
+    OSVR_CBool (*swapBuffers)(void* data, size_t display);
+    OSVR_CBool (*setVerticalSync)(void* data, OSVR_CBool verticalSync);
+    OSVR_CBool (*handleEvents)(void* data);
+} OSVR_OpenGLToolkitFunctions;
+
 typedef struct OSVR_GraphicsLibraryOpenGL {
-    // intentionally left blank
+    OSVR_OpenGLToolkitFunctions* toolkit;
     int unused;  // C does not allow empty structures
 } OSVR_GraphicsLibraryOpenGL;
 

--- a/osvr/RenderKit/RenderManagerOpenGLCustom.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGLCustom.cpp
@@ -1,0 +1,90 @@
+/** d@file
+@brief Source file implementing OSVR rendering interface for OpenGL
+
+@date 2015
+
+@author
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "RenderManagerOpenGLCustom.h"
+
+#include <iostream>
+
+namespace osvr {
+namespace renderkit {
+    RenderManagerOpenGLCustom::RenderManagerOpenGLCustom(
+        OSVR_ClientContext context,
+        ConstructorParameters p,
+        const OSVR_OpenGLToolkitFunctions& functions)
+        : RenderManagerOpenGL(context, p) {
+        if (functions.size != sizeof (OSVR_OpenGLToolkitFunctions)) {
+            m_doingOkay = false;
+            std::cerr << "osvr::renderkit::RenderManagerOpenGLCustom:"
+                      << "Unknown size for OSVR_OpenGLToolkitFunctions struct" << std::endl;
+            return;
+        }
+
+        this->functions = functions;
+        this->functions.create(this->functions.data);
+    }
+
+    RenderManagerOpenGLCustom::~RenderManagerOpenGLCustom() {
+        removeOpenGLContexts();
+        this->functions.destroy(this->functions.data);
+    }
+
+    bool RenderManagerOpenGLCustom::addOpenGLContext(GLContextParams p) {
+        OSVR_OpenGLContextParams params;
+        params.windowTitle = p.windowTitle.c_str();
+        params.displayIndex = p.displayIndex;
+        params.fullScreen = p.fullScreen;
+        params.width = p.width;
+        params.height = p.height;
+        params.xPos = p.xPos;
+        params.yPos = p.yPos;
+        params.bitsPerPixel = p.bitsPerPixel;
+        params.numBuffers = p.numBuffers;
+        params.visible = p.visible;
+
+        return functions.addOpenGLContext(functions.data, &params);
+    }
+
+    bool RenderManagerOpenGLCustom::removeOpenGLContexts() {
+        return functions.removeOpenGLContexts(functions.data);
+    }
+
+    bool RenderManagerOpenGLCustom::makeCurrent(size_t display) {
+        return functions.makeCurrent(functions.data, display);
+    }
+
+    bool RenderManagerOpenGLCustom::swapBuffers(size_t display) {
+        return functions.swapBuffers(functions.data, display);
+    }
+
+    bool RenderManagerOpenGLCustom::setVerticalSync(bool verticalSync) {
+        return functions.setVerticalSync(functions.data, verticalSync);
+    }
+
+    bool RenderManagerOpenGLCustom::handleEvents() {
+        return functions.handleEvents(functions.data);
+    }
+
+
+} // namespace renderkit
+} // namespace osvr

--- a/osvr/RenderKit/RenderManagerOpenGLCustom.h
+++ b/osvr/RenderKit/RenderManagerOpenGLCustom.h
@@ -1,0 +1,65 @@
+/** @file
+@brief Header file describing the OSVR direct-to-device rendering interface for
+OpenGL
+
+@date 2015
+
+@author
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "RenderManagerOpenGL.h"
+#include <osvr/RenderKit/RenderManagerOpenGLC.h>
+
+namespace osvr {
+namespace renderkit {
+
+    class RenderManagerOpenGLCustom : public RenderManagerOpenGL {
+      public:
+        virtual ~RenderManagerOpenGLCustom();
+
+      protected:
+        /// Construct an OpenGL render manager.
+        RenderManagerOpenGLCustom(
+            OSVR_ClientContext context,
+            ConstructorParameters p,
+            const OSVR_OpenGLToolkitFunctions& functions);
+
+        bool addOpenGLContext(GLContextParams p) override;
+        bool removeOpenGLContexts() override;
+
+        bool makeCurrent(size_t display) override;
+
+        bool swapBuffers(size_t display) override;
+
+        bool setVerticalSync(bool verticalSync) override;
+
+        bool handleEvents() override;
+
+      private:
+        OSVR_OpenGLToolkitFunctions functions;
+
+        friend RenderManager OSVR_RENDERMANAGER_EXPORT*
+        createRenderManager(OSVR_ClientContext context,
+                            const std::string& renderLibraryName,
+                            GraphicsLibrary graphicsLibrary);
+    };
+
+} // namespace renderkit
+} // namespace osvr

--- a/osvr/RenderKit/RenderManagerOpenGLSDL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGLSDL.cpp
@@ -1,0 +1,194 @@
+/** d@file
+@brief Source file implementing OSVR rendering interface for OpenGL
+
+@date 2015
+
+@author
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "RenderManagerOpenGLSDL.h"
+#include <RenderManagerBackends.h>
+#include "GraphicsLibraryOpenGL.h"
+#include "RenderManagerSDLInitQuit.h"
+
+namespace osvr {
+namespace renderkit {
+
+    RenderManagerOpenGLSDL::RenderManagerOpenGLSDL(
+        OSVR_ClientContext context,
+        ConstructorParameters p)
+        : RenderManagerOpenGL(context, p) {
+        m_GLContext = nullptr;
+    }
+
+    RenderManagerOpenGLSDL::~RenderManagerOpenGLSDL() {
+        removeOpenGLContexts();
+    }
+
+    bool RenderManagerOpenGLSDL::addOpenGLContext(GLContextParams p) {
+        // Initialize the SDL video subsystem.
+        if (!osvr::renderkit::SDLInitQuit()) {
+            std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not "
+                          "initialize SDL"
+                      << std::endl;
+            return false;
+        }
+
+        // Figure out the flags we want
+        Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
+        if (p.fullScreen) {
+            //        flags |= SDL_WINDOW_FULLSCREEN | SDL_WINDOW_BORDERLESS;
+            flags |= SDL_WINDOW_BORDERLESS;
+        }
+        if (p.visible) {
+            flags |= SDL_WINDOW_SHOWN;
+        } else {
+            flags |= SDL_WINDOW_HIDDEN;
+        }
+
+        // Set the OpenGL attributes we want before opening the window
+        if (p.numBuffers > 1) {
+            SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+        }
+        SDL_GL_SetAttribute(SDL_GL_RED_SIZE, p.bitsPerPixel);
+        SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, p.bitsPerPixel);
+        SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, p.bitsPerPixel);
+        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, p.bitsPerPixel);
+        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+        SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+#ifdef __APPLE__
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
+            SDL_GL_CONTEXT_PROFILE_CORE);
+#endif
+
+        // For now, append the display ID to the title.
+        /// @todo Make a different title for each window in the config file
+        char displayId = '0' + static_cast<char>(m_displays.size());
+        std::string windowTitle = m_params.m_windowTitle + displayId;
+
+        // For now, move the X position of the second display to the
+        // right of the entire display for the left one.
+        /// @todo Make the config-file entry a vector and read both
+        /// from it.
+        p.xPos += p.width * static_cast<int>(m_displays.size());
+
+        // If this is not the first display, or if the configuration
+        // includes a graphics library that says to share, we re-use
+        // the existing context.
+        if ((m_displays.size() > 0) ||
+          ((m_params.m_graphicsLibrary.OpenGL != nullptr) &&
+          (m_params.m_graphicsLibrary.OpenGL->shareOpenGLContext == true))) {
+
+          // Share the current context
+          SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
+        } else {
+          // Replace the current context
+          SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 0);
+        }
+
+        // Push back a new window and context.
+        m_displays.push_back(DisplayInfo());
+        m_displays.back().m_window = SDL_CreateWindow(
+            windowTitle.c_str(), p.xPos, p.yPos, p.width, p.height, flags);
+        if (m_displays.back().m_window == nullptr) {
+            std::cerr
+                << "RenderManagerOpenGL::addOpenGLContext: Could not get window"
+                << std::endl;
+            return false;
+        }
+
+        m_GLContext = SDL_GL_CreateContext(m_displays.back().m_window);
+        if (m_GLContext == nullptr) {
+            std::cerr << "RenderManagerOpenGL::addOpenGLContext: Could not get "
+                         "OpenGL context"
+                      << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool RenderManagerOpenGLSDL::removeOpenGLContexts() {
+        deleteProgram();
+        if (m_GLContext) {
+            SDL_GL_DeleteContext(m_GLContext);
+            m_GLContext = 0;
+        }
+        while (m_displays.size() > 0) {
+            if (m_displays.back().m_window == nullptr) {
+                std::cerr << "RenderManagerOpenGL::closeOpenGLContext: No "
+                             "window pointer"
+                          << std::endl;
+                return false;
+            }
+            SDL_DestroyWindow(m_displays.back().m_window);
+            m_displays.back().m_window = nullptr;
+            m_displays.pop_back();
+        }
+        return true;
+    }
+
+    bool RenderManagerOpenGLSDL::makeCurrent(size_t display) {
+        SDL_GL_MakeCurrent(m_displays[display].m_window, m_GLContext);
+        return true;
+    }
+
+    bool RenderManagerOpenGLSDL::swapBuffers(size_t display) {
+        SDL_GL_SwapWindow(m_displays[display].m_window);
+        return true;
+    }
+
+    bool RenderManagerOpenGLSDL::setVerticalSync(bool verticalSync) {
+        if (verticalSync) {
+            if (SDL_GL_SetSwapInterval(1) != 0) {
+                std::cerr << "RenderManagerOpenGL::OpenDisplay: Warning: Could "
+                             "not set vertical retrace on"
+                          << std::endl;
+                return false;
+            }
+        } else {
+            if (SDL_GL_SetSwapInterval(0) != 0) {
+                std::cerr << "RenderManagerOpenGL::OpenDisplay: Warning: Could "
+                             "not set vertical retrace off"
+                          << std::endl;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool RenderManagerOpenGLSDL::handleEvents() {
+        // Let SDL handle any system events that it needs to.
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            // If SDL has been given a quit event, what should we do?
+            // We return false to let the app know that something went wrong.
+            if (e.window.event == SDL_WINDOWEVENT_CLOSE) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+} // namespace renderkit
+} // namespace osvr

--- a/osvr/RenderKit/RenderManagerOpenGLSDL.h
+++ b/osvr/RenderKit/RenderManagerOpenGLSDL.h
@@ -1,0 +1,79 @@
+/** @file
+@brief Header file describing the OSVR direct-to-device rendering interface for
+OpenGL
+
+@date 2015
+
+@author
+Sensics, Inc.
+<http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "RenderManagerOpenGL.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <SDL.h>
+#ifndef RM_USE_OPENGLES20
+  #include <SDL_opengl.h>
+#endif
+
+namespace osvr {
+namespace renderkit {
+
+    class RenderManagerOpenGLSDL : public RenderManagerOpenGL {
+      public:
+        virtual ~RenderManagerOpenGLSDL();
+
+      protected:
+        /// Construct an OpenGL render manager.
+        RenderManagerOpenGLSDL(
+            OSVR_ClientContext context,
+            ConstructorParameters p);
+
+        bool addOpenGLContext(GLContextParams p) override;
+        bool removeOpenGLContexts() override;
+
+        bool makeCurrent(size_t display) override;
+
+        bool swapBuffers(size_t display) override;
+
+        bool setVerticalSync(bool verticalSync) override;
+
+        bool handleEvents() override;
+
+        // Classes and structures needed to do our rendering.
+        class DisplayInfo {
+          public:
+            SDL_Window* m_window = nullptr; //< The window we're rendering into
+        };
+        std::vector<DisplayInfo> m_displays;
+
+        SDL_GLContext
+            m_GLContext; //< The context we use to render to all displays
+
+        friend RenderManager OSVR_RENDERMANAGER_EXPORT*
+        createRenderManager(OSVR_ClientContext context,
+                            const std::string& renderLibraryName,
+                            GraphicsLibrary graphicsLibrary);
+    };
+
+} // namespace renderkit
+} // namespace osvr

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -7,6 +7,7 @@ set(IGNORED_HEADERS
         RenderKit/GraphicsLibraryOpenGL.h
         RenderKit/GraphicsLibraryD3D11.h
         RenderKit/RenderManagerOpenGL.h
+        RenderKit/RenderManagerOpenGLSDL.h
         RenderKit/RenderManagerD3D.h
         RenderKit/RenderManagerD3D11ATW.h
         RenderKit/RenderManagerD3DOpenGL.h
@@ -32,11 +33,11 @@ endif()
 
 if (SDL2_FOUND)
 	set(LIBRARIES_RenderKit_RenderManagerSDLInitQuit SDL2::SDL2)
-	set(LIBRARIES_RenderKit_RenderManagerOpenGL SDL2::SDL2)
+	set(LIBRARIES_RenderKit_RenderManagerOpenGLSDL SDL2::SDL2)
 else()
 	list(APPEND IGNORED_HEADERS
 		RenderKit/RenderManagerSDLInitQuit.h
-		RenderKit/RenderManagerOpenGL.h)
+		RenderKit/RenderManagerOpenGLSDL.h)
 endif()
 
 set(COMMON_TEST_LIBRARIES osvrRenderManager)


### PR DESCRIPTION
Allow the application to specify a set of methods for creating the window,
making then OpenGL context current etc. This makes it possible to use
toolkits other than SDL.
An example showing how to use RenderKit with Qt5 is included.