### PR TITLE
Modified RenderManagerOpenGL.h and RenderManagerOpenGLC.h to not incl…

### DIFF
--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -27,14 +27,13 @@ Sensics, Inc.
 #include <osvr/ClientKit/Context.h>
 #include <osvr/ClientKit/Interface.h>
 #include "RenderManager.h"
-#include <RenderManagerBackends.h>
-#include "RenderManagerOpenGLC.h"
+#include <osvr/Util/PlatformConfig.h>
 
-#ifdef _WIN32
+#if defined(OSVR_WINDOWS)
 #include <windows.h>
 #endif
 
-#ifdef RM_USE_OPENGLES20
+#ifdef OSVR_ANDROID
   // @todo This presumes we're compiling on Android.
   #include <GLES2/gl2.h>
   #include <GLES2/gl2ext.h>
@@ -70,6 +69,7 @@ Sensics, Inc.
   #endif
 #endif
 
+#include "RenderManagerOpenGLC.h"
 #include <stdlib.h>
 
 #include <vector>

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -26,7 +26,6 @@
 #define INCLUDED_RenderManagerOpenGLC_h_GUID_362705F9_1D6B_468E_3532_B813F7AB50C6
 
 // Internal Includes
-#include <RenderManagerBackends.h>
 #include <osvr/RenderKit/RenderManagerC.h>
 
 // Library/third-party includes
@@ -35,7 +34,7 @@
 #include <windows.h>
 #endif
 
-#ifdef RM_USE_OPENGLES20
+#ifdef OSVR_ANDROID
 // @todo This presumes we're compiling on Android.
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>


### PR DESCRIPTION
…ude generated platform-specific header RenderManagerBackends.h. This however assumes OSVR_ANDROID only for GLES, for now.