### PR TITLE
Added getDisplaySizeOverride callback to OSVR_OpenGLToolkitFunctions

### DIFF
--- a/examples/RenderManagerOpenGLQt5Example.cpp
+++ b/examples/RenderManagerOpenGLQt5Example.cpp
@@ -109,6 +109,9 @@ class Qt5ToolkitImpl {
     static OSVR_CBool getDisplayFrameBufferImpl(void* data, size_t display, GLint* displayFrameBufferOut) {
       return ((Qt5ToolkitImpl*)data)->getDisplayFrameBuffer(display, displayFrameBufferOut);
     }
+    static OSVR_CBool getDisplaySizeOverrideImpl(void* data, size_t display, int* width, int* height) {
+        return ((Qt5ToolkitImpl*)data)->getDisplaySizeOverride(display, width, height);
+    }
 
     QList<QGLWidget*> glwidgets;
     QList<QWidget*> widgets;
@@ -127,6 +130,7 @@ class Qt5ToolkitImpl {
         toolkit.swapBuffers = swapBuffersImpl;
         toolkit.setVerticalSync = setVerticalSyncImpl;
         toolkit.handleEvents = handleEventsImpl;
+        toolkit.getDisplaySizeOverride = getDisplaySizeOverrideImpl;
     }
 
     ~Qt5ToolkitImpl() {
@@ -200,6 +204,10 @@ class Qt5ToolkitImpl {
     bool getDisplayFrameBuffer(size_t display, GLint* displayFrameBufferOut) {
       *displayFrameBufferOut = 0;
       return true;
+    }
+    bool getDisplaySizeOverride(size_t display, int* width, int* height) {
+        // we don't override the display. Use default behavior.
+        return false;
     }
 };
 

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -76,6 +76,9 @@ class SDLToolkitImpl {
   static OSVR_CBool getDisplayFrameBufferImpl(void* data, size_t display, GLint* displayFrameBufferOut) {
       return ((SDLToolkitImpl*)data)->getDisplayFrameBuffer(display, displayFrameBufferOut);
   }
+  static OSVR_CBool getDisplaySizeOverrideImpl(void* data, size_t display, int* width, int* height) {
+      return ((SDLToolkitImpl*)data)->getDisplaySizeOverride(display, width, height);
+  }
 
   // Classes and structures needed to do our rendering.
   class DisplayInfo {
@@ -102,6 +105,7 @@ public:
     toolkit.setVerticalSync = setVerticalSyncImpl;
     toolkit.handleEvents = handleEventsImpl;
     toolkit.getDisplayFrameBuffer = getDisplayFrameBufferImpl;
+    toolkit.getDisplaySizeOverride = getDisplaySizeOverrideImpl;
   }
 
   ~SDLToolkitImpl() {
@@ -248,6 +252,11 @@ public:
       *displayFrameBufferOut = 0;
       return true;
   }
+
+  bool getDisplaySizeOverride(size_t display, int* width, int* height) {
+      // we don't override the display. Use default behavior.
+      return false;
+  }
 };
 
 //==========================================================================
@@ -370,6 +379,15 @@ namespace renderkit {
         // Construct the appropriate GraphicsLibrary pointer.
         m_library.OpenGL = new GraphicsLibraryOpenGL;
         m_buffers.OpenGL = new RenderBufferOpenGL;
+
+        // @todo: there's only one m_displayWidth and m_displayHeight member pair
+        // and it corresponds to display 0. Probably should be made more generic?
+        size_t display = 0;
+        int widthOverride, heightOverride;
+        if (m_toolkit.getDisplaySizeOverride && m_toolkit.getDisplaySizeOverride(m_toolkit.data, display, &widthOverride, &heightOverride)) {
+            m_displayWidth = widthOverride;
+            m_displayHeight = heightOverride;
+        }
     }
 
     RenderManagerOpenGL::~RenderManagerOpenGL() {

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -100,6 +100,7 @@ typedef struct OSVR_OpenGLToolkitFunctions {
     OSVR_CBool (*setVerticalSync)(void* data, OSVR_CBool verticalSync);
     OSVR_CBool (*handleEvents)(void* data);
     OSVR_CBool (*getDisplayFrameBuffer)(void* data, size_t display, GLint* frameBufferOut);
+    OSVR_CBool (*getDisplaySizeOverride)(void* data, size_t display, int* width, int* height);
 } OSVR_OpenGLToolkitFunctions;
 
 typedef struct OSVR_GraphicsLibraryOpenGL {


### PR DESCRIPTION
In OSVR-Unreal, we need an override to change the display size, because of mobile scaling. The actual display size may end up being smaller than the physical resolution. This new callback allows a custom toolkit to override the display size.

Implements: https://github.com/sensics/OSVR-RenderManager/issues/161