### PR TITLE
Allocate space (and later delete it) for storing the window name when…

### DIFF
--- a/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.cpp
@@ -117,6 +117,7 @@ namespace renderkit {
                               "context";
             return ret;
         }
+        ReleaseContextParams(pC);
         glewExperimental = true; // Needed for core profile
         if (glewInit() != GLEW_OK) {
           if (m_toolkit.removeOpenGLContexts) {

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -547,9 +547,16 @@ namespace renderkit {
 
           // For now, append the display ID to the title.
           /// @todo Make a different title for each window in the config file
+          ReleaseContextParams(pC); // @todo Remove when there is one per display
           char displayId = '0' + static_cast<int>(display);
           std::string windowTitle = p.windowTitle + displayId;
-          pC.windowTitle = windowTitle.c_str();
+          std::unique_ptr<char> title(new char[windowTitle.size() + 1]);
+          // Note: This will not cause a constraint violation because we've
+          // satisfied all of the constraints, so we don't need to wrap it in
+          // a handler.
+          strncpy_s(title.get(), windowTitle.size() + 1,
+            windowTitle.c_str(), windowTitle.size() + 1);
+          pC.windowTitle = title.get();
 
           // For now, move the X position of the second display to the
           // right of the entire display for the left one.


### PR DESCRIPTION
… converting from std::string to char * in the transition from C++ to C for a structure.

This avoids keeping data around beyond the time it is promised to be defined.