### PR TITLE
include "vrpn_Shared.h"

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -79,6 +79,8 @@ Russ Taylor <russ@sensics.com>
 #include <json/value.h>
 #include <json/reader.h>
 
+#include <vrpn_Shared.h>
+
 // Standard includes
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
fixes
```
/home/chris/build/osvr-rendermanager/src/osvr-rendermanager/osvr/RenderKit/RenderManagerBase.cpp: In member function 'virtual bool osvr::renderkit::RenderManager::PresentRenderBuffersInternal(const std::vector<osvr::renderkit::RenderBuffer>&, const std::vector<osvr::renderkit::RenderInfo>&, const osvr::renderkit::RenderManager::RenderParams&, const std::vector<osvr::renderkit::OSVR_ViewportDescription>&, bool)':
/home/chris/build/osvr-rendermanager/src/osvr-rendermanager/osvr/RenderKit/RenderManagerBase.cpp:726:45: error: 'vrpn_gettimeofday' was not declared in this scope
         vrpn_gettimeofday(&allStart, nullptr);
                                             ^
/home/chris/build/osvr-rendermanager/src/osvr-rendermanager/osvr/RenderKit/RenderManagerBase.cpp:749:77: error: 'vrpn_TimevalDurationSeconds' was not declared in this scope
         timePresentFrameInitilize += vrpn_TimevalDurationSeconds(stop, start);
                                                                             ^
```