### PR TITLE
Factor out vendors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set (RenderManager_SOURCES
 	osvr/RenderKit/RenderKitGraphicsTransforms.cpp
 	osvr/RenderKit/osvr_display_configuration.cpp
 	osvr/RenderKit/DistortionParameters.cpp
+	osvr/RenderKit/DirectModeVendors.h
 	osvr/RenderKit/VendorIdTools.h
 	osvr/RenderKit/osvr_display_config_built_in_osvr_hdks.h
 	osvr/RenderKit/DistortionCorrectTextureCoordinate.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set (RenderManager_SOURCES
 	osvr/RenderKit/RenderKitGraphicsTransforms.cpp
 	osvr/RenderKit/osvr_display_configuration.cpp
 	osvr/RenderKit/DistortionParameters.cpp
+	osvr/RenderKit/CleanPNPIDString.h
 	osvr/RenderKit/DirectModeVendors.h
 	osvr/RenderKit/VendorIdTools.h
 	osvr/RenderKit/osvr_display_config_built_in_osvr_hdks.h

--- a/osvr/RenderKit/CleanPNPIDString.h
+++ b/osvr/RenderKit/CleanPNPIDString.h
@@ -1,0 +1,64 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_CleanPNPIDString_h_GUID_31D738A4_19B2_49A4_C1A5_12AC5AF30874
+#define INCLUDED_CleanPNPIDString_h_GUID_31D738A4_19B2_49A4_C1A5_12AC5AF30874
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+#include <boost/algorithm/string/case_conv.hpp>
+
+// Standard includes
+#include <string>
+
+namespace osvr {
+namespace renderkit {
+    namespace vendorid {
+        /// Given a character sequence that might be a PNPID, clean it up (all caps, check constraints), and either
+        /// return it as a string, or return an empty string if it failed somewhere.
+        template <typename T> inline std::string cleanPotentialPNPID(T const& input) {
+            auto ret = std::string{};
+            std::string pnpid{input};
+            boost::algorithm::to_upper(pnpid);
+            if (pnpid.size() != 3) {
+                /// wrong length
+                return ret;
+            }
+
+            for (auto c : pnpid) {
+                if (c < 'A' || c > 'Z') {
+                    /// character out of range
+                    return ret;
+                }
+            }
+            ret = std::move(pnpid);
+            return ret;
+        }
+    } // namespace vendorid
+
+} // namespace renderkit
+} // namespace osvr
+#endif // INCLUDED_CleanPNPIDString_h_GUID_31D738A4_19B2_49A4_C1A5_12AC5AF30874

--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -1,0 +1,120 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_DirectModeVendors_h_GUID_DFCDE7B9_78B9_44B1_85A5_2E661722FF93
+#define INCLUDED_DirectModeVendors_h_GUID_DFCDE7B9_78B9_44B1_85A5_2E661722FF93
+
+// Internal Includes
+#include <osvr/RenderKit/VendorIdTools.h>
+
+// Library/third-party includes
+#include <osvr/Common/IntegerByteSwap.h>
+
+// Standard includes
+#include <string>
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+
+namespace osvr {
+namespace renderkit {
+    namespace vendorid {
+        using PNPIDNullTerminatedType = std::array<char, 4>;
+        class DirectModeVendorEntry {
+          public:
+            explicit DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid)
+                : pnpid_(pnpid), displayDescriptorVendor(pnpid.data()) {}
+            DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid, const char* dispDescVend)
+                : pnpid_(pnpid), displayDescriptorVendor(dispDescVend) {}
+            DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid, const char* dispDescVend, const char* desc)
+                : pnpid_(pnpid), displayDescriptorVendor(dispDescVend), description(desc) {}
+
+            /// 3 character, all-caps, in A-Z, PNPID, preferably registered through the UEFI registry.
+            PNPIDNullTerminatedType const& getPNPIDCharArray() const { return pnpid_; }
+
+            const char* getPNPIDCString() const { return pnpid_.data(); }
+            std::uint16_t getFlippedHexPNPID() const {
+                /// @todo will this only work on little-endian systems? Need to figure out why the byte swap is needed.
+                return common::integerByteSwap(pnpidToHex(getPNPIDCharArray()));
+            }
+            std::string const& getDisplayDescriptorVendor() const { return displayDescriptorVendor; }
+            std::string const& getDescription() const {
+                return description.empty() ? displayDescriptorVendor : description;
+            }
+
+          private:
+            PNPIDNullTerminatedType pnpid_;
+            /// Vendor string to match in display descriptor.
+            std::string displayDescriptorVendor;
+            /// Description - if left empty, getDescription will return displayDescriptorVendor instead.
+            std::string description;
+        };
+
+        using DirectModeVendors = std::vector<DirectModeVendorEntry>;
+        static inline std::vector<DirectModeVendors> combineSharedPNPIDs(DirectModeVendors const& vendors) {
+            std::vector<DirectModeVendors> ret;
+            for (auto& entry : vendors) {
+                const auto e = ret.end();
+                auto existingEntryIt = std::find_if(ret.begin(), e, [&](DirectModeVendors const& vendorList) {
+                    return vendorList.front().getPNPIDCharArray() == entry.getPNPIDCharArray();
+                });
+                if (e == existingEntryIt) {
+                    // no existing entry
+                    ret.emplace_back(DirectModeVendors{entry});
+                } else {
+                    // add to existing entry.
+                    existingEntryIt->push_back(entry);
+                }
+            }
+            return ret;
+        }
+    } // namespace vendorid
+    using vendorid::DirectModeVendors;
+    static DirectModeVendors const& getDefaultVendors() {
+        using Vendor = vendorid::DirectModeVendorEntry;
+        static DirectModeVendors vendors =
+            DirectModeVendors{Vendor{{"OVR"}, "Oculus"},
+                              Vendor{{"SEN"}, "Sensics", "Some Sensics professional displays"},
+                              Vendor{{"SVR"}, "Sensics", "Some Sensics professional displays"},
+                              Vendor{{"SEN"}, "OSVR", "Some OSVR HDK units with early firmware/EDID data"},
+                              Vendor{{"SVR"}, "OSVR", "Most OSVR HDK units"},
+                              Vendor{{"AUO"}, "OSVR", "Some OSVR HDK2 firmware versions"},
+                              Vendor{{"VVR"}},
+                              Vendor{{"IWR"}, "Vuzix"},
+                              Vendor{{"HVR"}, "HTC"},
+                              Vendor{{"AVR"}},
+                              Vendor{{"VRG"}, "VRGate"},
+                              Vendor{{"TSB"}, "VRGate"},
+                              Vendor{{"VRV"}, "Vrvana"}};
+        return vendors;
+    }
+
+    static std::vector<DirectModeVendors> const& getDefaultVendorsByPNPID() {
+        static std::vector<DirectModeVendors> vendorsByPNPID = vendorid::combineSharedPNPIDs(getDefaultVendors());
+        return vendorsByPNPID;
+    }
+} // namespace renderkit
+} // namespace osvr
+#endif // INCLUDED_DirectModeVendors_h_GUID_DFCDE7B9_78B9_44B1_85A5_2E661722FF93


### PR DESCRIPTION
This is a refactoring that pulls the association of PNPID with device descriptor vendor name and a "human readable" string (like "most OSVR HDK devices") out of a massive if-else in RenderManagerBase  (and in part, the enable/disable direct mode tools) and into a data structure (static, in a header, so the direct mode enable/disable still won't need to link against rendermanager to use it).

This is the first part of the de-duplication of this data - pull requests on the submodules will come as well, so this new header will be the single source of truth for hard-coded PNPIDs.

This also contains support for "testing" or otherwise custom PNPIDs - if a vendor name is not found in the list, but take the form of 3 characters in `[A-Z]`, it will be added as a candidate pnpid, allowing testing without needing to recompile rendermanager.

This pull request still needs testing.