### PR TITLE
Adding a CMAKE_DEBUG_POSTFIX entry if it does not exist, letting the …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,15 @@ if(WIN32)
 		NO_DEFAULT_PATH)
 endif()
 
+# Set the debug postfix
+if(WIN32 AND NOT DEFINED CMAKE_DEBUG_POSTFIX)
+    set(OSVR_SET_DEBUG_POSTFIX TRUE)
+    set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+if(WIN32 AND OSVR_SET_DEBUG_POSTFIX)
+    set(CMAKE_DEBUG_POSTFIX "")
+endif()
+
 # These configurations have the tools installed.
 set(TOOL_CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
 


### PR DESCRIPTION
…user set it and setting the default to 'd'.