### PR TITLE
Vendor initializers

### DIFF
--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -71,15 +71,14 @@ namespace renderkit {
             /// @param dispDescVend A string literal used as a "Vendor" string in an OSVR Display Descriptor (schema v1)
             /// that should trigger searching for devices with this PNPID.
             DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend)
-                : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend) {}
+                : pnpid_(stringLiteralPNPIDToArray(pnpid)), displayDescriptorVendor(dispDescVend) {}
             /// @brief Elaborated entry
             /// @param pnpid See above
             /// @param dispDescVend See above
             /// @param desc A human-readable description of devices with this vendor and PNPID. For instance, when a
             /// single vendor has multiple devices with PNPIDs, and/or when multiple vendors share a PNPID.
             DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend, const char* desc)
-                : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend),
-                  description(desc) {}
+                : pnpid_(stringLiteralPNPIDToArray(pnpid)), displayDescriptorVendor(dispDescVend), description(desc) {}
             /// @}
 
             /// @brief Returns the PNPID as a std::array of chars including the null terminator:

--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -44,29 +44,70 @@ namespace renderkit {
     namespace vendorid {
         using PNPIDNullTerminatedType = std::array<char, 4>;
         using PNPIDStringLiteralType = std::add_lvalue_reference<const char[4]>::type;
+
+        /// @brief A class storing an association between a PNPID vendor ID as found in EDID data, a "Vendor" name as
+        /// found in OSVR display descriptor files (schema v1), and an optional user-friendly description.
+        ///
+        /// Used primarily in a static data table processed at runtime (replacing extensive conditionals and ad-hoc code
+        /// repetition) by various apps and libraries.
         class DirectModeVendorEntry {
           public:
+            /// @name Constructors
+            /// @brief Used to create entries in the table of vendors, Identically-named parameters perform identically
+            /// between constructors.
+            /// @{
+            /// @brief Minimal/brief/stealth entry - just PNPID. Sets the display descriptor vendor to be the same as
+            /// the PNPID.
+            /// @param pnpid A 3-character, all caps string literal matching /^[A-Z]+$/ . See getPNPNIDCharArray() for
+            /// details. WARNING: For speed of initialization, your input here is not validated to ensure it is
+            /// all-caps, A-Z only!
             explicit DirectModeVendorEntry(PNPIDStringLiteralType pnpid) : DirectModeVendorEntry(pnpid, pnpid) {}
+            /// @brief Basic/common entry
+            /// @param pnpid See above
+            /// @param dispDescVend A string literal used as a "Vendor" string in an OSVR Display Descriptor (schema v1)
+            /// that should trigger searching for devices with this PNPID.
             DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend)
                 : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend) {}
+            /// @brief Elaborated entry
+            /// @param pnpid See above
+            /// @param dispDescVend See above
+            /// @param desc A human-readable description of devices with this vendor and PNPID. For instance, when a
+            /// single vendor has multiple devices with PNPIDs, and/or when multiple vendors share a PNPID.
             DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend, const char* desc)
                 : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend),
                   description(desc) {}
+            /// @}
 
-            /// 3 character, all-caps, in A-Z, PNPID, preferably registered through the UEFI registry.
+            /// @brief Returns the PNPID as a std::array of chars including the null terminator:
+            ///
+            /// 3 character, all-caps, in A-Z, PNPID, preferably registered through the UEFI registry. These should
+            /// technically be registered through http://www.uefi.org/PNP_ACPI_Registry (at least respecting assignments
+            /// made there) and must match the vendor ID reported in your EDID data (see Windows "Hardware IDs")
             PNPIDNullTerminatedType const& getPNPIDCharArray() const { return pnpid_; }
 
+            /// @brief Convenience method to access the data of getPNPIDCharArray() as a null-terminated C string.
             const char* getPNPIDCString() const { return pnpid_.data(); }
+
+            /// @brief Converts the PNPID to two hex bytes for use in an EDID, per the formula established by Microsoft,
+            /// then swaps the bytes as seems to be required by most consumers of this data.
             std::uint16_t getFlippedHexPNPID() const {
                 /// @todo will this only work on little-endian systems? Need to figure out why the byte swap is needed.
                 return common::integerByteSwap(pnpidToHex(getPNPIDCharArray()));
             }
+
+            /// @brief Returns the string as provided in the constructor.
             std::string const& getDisplayDescriptorVendor() const { return displayDescriptorVendor; }
+
+            /// @brief Returns the string provided in constructor, if any - if not, it returns the same as
+            /// getDisplayDescriptorVendor()
             std::string const& getDescription() const {
                 return description.empty() ? displayDescriptorVendor : description;
             }
 
           private:
+            /// PNPID as a std::array of chars including the null terminator.
+            /// std::array is used for bounds/type-safety and protection from decay-to-pointer as well as operator
+            /// overloads: it is easily compared, copied, etc.
             PNPIDNullTerminatedType pnpid_;
             /// Vendor string to match in display descriptor.
             std::string displayDescriptorVendor;

--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -37,19 +37,21 @@
 #include <vector>
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace osvr {
 namespace renderkit {
     namespace vendorid {
         using PNPIDNullTerminatedType = std::array<char, 4>;
+        using PNPIDStringLiteralType = std::add_lvalue_reference<const char[4]>::type;
         class DirectModeVendorEntry {
           public:
-            explicit DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid)
-                : pnpid_(pnpid), displayDescriptorVendor(pnpid.data()) {}
-            DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid, const char* dispDescVend)
-                : pnpid_(pnpid), displayDescriptorVendor(dispDescVend) {}
-            DirectModeVendorEntry(const PNPIDNullTerminatedType& pnpid, const char* dispDescVend, const char* desc)
-                : pnpid_(pnpid), displayDescriptorVendor(dispDescVend), description(desc) {}
+            explicit DirectModeVendorEntry(PNPIDStringLiteralType pnpid) : DirectModeVendorEntry(pnpid, pnpid) {}
+            DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend)
+                : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend) {}
+            DirectModeVendorEntry(PNPIDStringLiteralType pnpid, const char* dispDescVend, const char* desc)
+                : pnpid_({pnpid[0], pnpid[1], pnpid[2], pnpid[3]}), displayDescriptorVendor(dispDescVend),
+                  description(desc) {}
 
             /// 3 character, all-caps, in A-Z, PNPID, preferably registered through the UEFI registry.
             PNPIDNullTerminatedType const& getPNPIDCharArray() const { return pnpid_; }
@@ -94,20 +96,22 @@ namespace renderkit {
     using vendorid::DirectModeVendors;
     static DirectModeVendors const& getDefaultVendors() {
         using Vendor = vendorid::DirectModeVendorEntry;
-        static DirectModeVendors vendors =
-            DirectModeVendors{Vendor{{"OVR"}, "Oculus"},
-                              Vendor{{"SEN"}, "Sensics", "Some Sensics professional displays"},
-                              Vendor{{"SVR"}, "Sensics", "Some Sensics professional displays"},
-                              Vendor{{"SEN"}, "OSVR", "Some OSVR HDK units with early firmware/EDID data"},
-                              Vendor{{"SVR"}, "OSVR", "Most OSVR HDK units"},
-                              Vendor{{"AUO"}, "OSVR", "Some OSVR HDK2 firmware versions"},
-                              Vendor{{"VVR"}},
-                              Vendor{{"IWR"}, "Vuzix"},
-                              Vendor{{"HVR"}, "HTC"},
-                              Vendor{{"AVR"}},
-                              Vendor{{"VRG"}, "VRGate"},
-                              Vendor{{"TSB"}, "VRGate"},
-                              Vendor{{"VRV"}, "Vrvana"}};
+        static DirectModeVendors vendors = DirectModeVendors{
+            Vendor{"OVR", "Oculus"},
+            Vendor{"SEN", "Sensics", "Some Sensics professional displays"},
+            Vendor{"SVR", "Sensics", "Some Sensics professional displays"},
+            Vendor{"SEN", "OSVR", "Some OSVR HDK units with early firmware/EDID data"},
+            Vendor{"SVR", "OSVR", "Most OSVR HDK units"},
+            Vendor{"AUO", "OSVR", "Some OSVR HDK2 firmware versions"},
+            Vendor{"VVR"},
+            Vendor{"IWR", "Vuzix"},
+            Vendor{"HVR", "HTC"},
+            Vendor{"AVR"},
+            Vendor{"VRG", "VRGate"},
+            Vendor{"TSB", "VRGate"},
+            Vendor{"VRV", "Vrvana"},
+            /* add new vendors here - keep grouped by display descriptor vendor */
+        };
         return vendors;
     }
 

--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace osvr {
 namespace renderkit {
@@ -45,6 +46,11 @@ namespace renderkit {
         using PNPIDNullTerminatedType = std::array<char, 4>;
         using PNPIDStringLiteralType = std::add_lvalue_reference<const char[4]>::type;
 
+        /// This is in here, rather than VendorIdTools, since it uses an OSVR header, and that file doesn't need
+        /// anything but some simple standard headers.
+        template <typename T> inline std::uint16_t pnpidToFlippedHex(T&& pnpid) {
+            return common::integerByteSwap(pnpidToHex(std::forward<T>(pnpid)));
+        }
         /// @brief A class storing an association between a PNPID vendor ID as found in EDID data, a "Vendor" name as
         /// found in OSVR display descriptor files (schema v1), and an optional user-friendly description.
         ///
@@ -92,7 +98,7 @@ namespace renderkit {
             /// then swaps the bytes as seems to be required by most consumers of this data.
             std::uint16_t getFlippedHexPNPID() const {
                 /// @todo will this only work on little-endian systems? Need to figure out why the byte swap is needed.
-                return common::integerByteSwap(pnpidToHex(getPNPIDCharArray()));
+                return pnpidToFlippedHex(getPNPIDCharArray());
             }
 
             /// @brief Returns the string as provided in the constructor.
@@ -134,7 +140,10 @@ namespace renderkit {
             return ret;
         }
     } // namespace vendorid
+
+    using vendorid::pnpidToFlippedHex;
     using vendorid::DirectModeVendors;
+
     static DirectModeVendors const& getDefaultVendors() {
         using Vendor = vendorid::DirectModeVendorEntry;
         static DirectModeVendors vendors = DirectModeVendors{

--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -43,8 +43,6 @@
 namespace osvr {
 namespace renderkit {
     namespace vendorid {
-        using PNPIDNullTerminatedType = std::array<char, 4>;
-        using PNPIDStringLiteralType = std::add_lvalue_reference<const char[4]>::type;
 
         /// This is in here, rather than VendorIdTools, since it uses an OSVR header, and that file doesn't need
         /// anything but some simple standard headers.
@@ -89,7 +87,7 @@ namespace renderkit {
             /// 3 character, all-caps, in A-Z, PNPID, preferably registered through the UEFI registry. These should
             /// technically be registered through http://www.uefi.org/PNP_ACPI_Registry (at least respecting assignments
             /// made there) and must match the vendor ID reported in your EDID data (see Windows "Hardware IDs")
-            PNPIDNullTerminatedType const& getPNPIDCharArray() const { return pnpid_; }
+            PNPIDNullTerminatedStdArray const& getPNPIDCharArray() const { return pnpid_; }
 
             /// @brief Convenience method to access the data of getPNPIDCharArray() as a null-terminated C string.
             const char* getPNPIDCString() const { return pnpid_.data(); }
@@ -114,7 +112,7 @@ namespace renderkit {
             /// PNPID as a std::array of chars including the null terminator.
             /// std::array is used for bounds/type-safety and protection from decay-to-pointer as well as operator
             /// overloads: it is easily compared, copied, etc.
-            PNPIDNullTerminatedType pnpid_;
+            PNPIDNullTerminatedStdArray pnpid_;
             /// Vendor string to match in display descriptor.
             std::string displayDescriptorVendor;
             /// Description - if left empty, getDescription will return displayDescriptorVendor instead.

--- a/osvr/RenderKit/VendorIdTools.h
+++ b/osvr/RenderKit/VendorIdTools.h
@@ -53,29 +53,26 @@ namespace renderkit {
         static const std::size_t BIT_OFFSET_2 = 0;
 
         static const std::uint16_t LETTER_MASK =
-            2 * 2 * 2 * 2 * 2 -
-            1; /// 5 bits allocated for each letter, so mask is 2^5 -1
+            2 * 2 * 2 * 2 * 2 - 1; /// 5 bits allocated for each letter, so mask is 2^5 -1
 
         /// Convert one A-Z letter to a hex value, unshifted.
         inline std::uint16_t charToHex(char const letter) {
             /// @todo is the mask helpful? It's theoretically redundant, but it
             /// ensures we don't mess up anyone else's spot.
-            return (std::toupper(letter) - BASE_LETTER + BASE_VALUE) &
-                   LETTER_MASK;
+            return (std::toupper(letter) - BASE_LETTER + BASE_VALUE) & LETTER_MASK;
         }
 
         /// Convert one unshifted hex value back to an A-Z letter.
         inline char hexToChar(std::uint16_t isolatedLetter) {
-            return static_cast<char>(isolatedLetter & LETTER_MASK) -
-                   BASE_VALUE + BASE_LETTER;
+            return static_cast<char>(isolatedLetter & LETTER_MASK) - BASE_VALUE + BASE_LETTER;
         }
 
         /// Convert something stringy of length 3, intended to be a PNPID,
         /// into the hex equivalent.
         /// Note that NVIDIA likes the byte order flipped.
         template <typename T> inline std::uint16_t pnpidToHex(T const& pnpid) {
-            return (charToHex(pnpid[0]) << BIT_OFFSET_0) |
-                   (charToHex(pnpid[1]) << BIT_OFFSET_1) |
+            return (charToHex(pnpid[0]) << BIT_OFFSET_0) | //
+                   (charToHex(pnpid[1]) << BIT_OFFSET_1) | //
                    (charToHex(pnpid[2]) << BIT_OFFSET_2);
         }
 
@@ -90,10 +87,13 @@ namespace renderkit {
         /// Convert the full two-byte hex VID into a null-terminated
         /// 3-character PNP ID.
         /// Note that NVIDIA likes the byte order flipped.
-        inline std::array<char, 4> fullHexVidToPnp(std::uint16_t vid) {
-            return std::array<char, 4>{hexToChar(vid >> BIT_OFFSET_0),
-                                       hexToChar(vid >> BIT_OFFSET_1),
-                                       hexToChar(vid >> BIT_OFFSET_2), '\0'};
+        inline PNPIDNullTerminatedStdArray fullHexVidToPnp(std::uint16_t vid) {
+            return PNPIDNullTerminatedStdArray{
+                hexToChar(vid >> BIT_OFFSET_0), //< shift off to put first character in bits 0-7 then decode
+                hexToChar(vid >> BIT_OFFSET_1), //< shift off for second character then decode
+                hexToChar(vid >> BIT_OFFSET_2), //< shift off for third character then decode
+                '\0'                            //< always null terminated
+            };
         }
     } // namespace vendorid
     using vendorid::pnpidToHex;

--- a/osvr/RenderKit/VendorIdTools.h
+++ b/osvr/RenderKit/VendorIdTools.h
@@ -84,6 +84,16 @@ namespace renderkit {
         /// compared, doesn't decay to a pointer type, but is otherwise the same in size and performance: a std::array
         /// of char with 4 elements (3 non-null and a null terminator)
         using PNPIDNullTerminatedStdArray = std::array<char, 4>;
+
+        /// Create a PNPIDNullTerminatedStdArray given a string literal (const char [4])
+        ///
+        /// Direct construction of PNPIDNullTerminatedStdArray from a const char [4], even wrapped in curly braces, is a
+        /// bit hit or miss - where misses include important environments like GCC 4.9, hence this helper function,
+        /// which also ensures null termination (but not any of the other invariants/requirements of a PNPID!)
+        inline PNPIDNullTerminatedStdArray stringLiteralPNPIDToArray(PNPIDStringLiteralType pnpid) {
+            return PNPIDNullTerminatedStdArray{pnpid[0], pnpid[1], pnpid[2], '\0'};
+        }
+
         /// Convert the full two-byte hex VID into a null-terminated
         /// 3-character PNP ID.
         /// Note that NVIDIA likes the byte order flipped.

--- a/osvr/RenderKit/VendorIdTools.h
+++ b/osvr/RenderKit/VendorIdTools.h
@@ -36,6 +36,7 @@
 #include <cstddef>
 #include <cctype>
 #include <array>
+#include <type_traits>
 
 namespace osvr {
 namespace renderkit {
@@ -78,6 +79,14 @@ namespace renderkit {
                    (charToHex(pnpid[2]) << BIT_OFFSET_2);
         }
 
+        /// This is explicitly a reference to a const char array of length 4 (intended for 3 characters and a null
+        /// terminator as a string literal) - this is the tidiest/least gross way to declare that type
+        using PNPIDStringLiteralType = std::add_lvalue_reference<const char[4]>::type;
+
+        /// This is the preferred alternative to PNPIDStringLiteralType's referred-to type since it is easily copied and
+        /// compared, doesn't decay to a pointer type, but is otherwise the same in size and performance: a std::array
+        /// of char with 4 elements (3 non-null and a null terminator)
+        using PNPIDNullTerminatedStdArray = std::array<char, 4>;
         /// Convert the full two-byte hex VID into a null-terminated
         /// 3-character PNP ID.
         /// Note that NVIDIA likes the byte order flipped.


### PR DESCRIPTION
This should fix the build on GCC 4.9 - apparently my previous syntax was technically legal (maybe) but the new syntax is more legal and more simple. Also more commented.

cc @JeroMiya 