### PR TITLE
Fix vao

### DIFF
--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -172,6 +172,7 @@ namespace renderkit {
             RenderManagerOpenGL* renderManager;
             size_t display;
 
+            GLuint VAO;
             GLuint vertexBuffer;
             GLuint indexBuffer;
             std::vector<DistortionVertex> vertices;

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -172,7 +172,9 @@ namespace renderkit {
             RenderManagerOpenGL* renderManager;
             size_t display;
 
+#ifndef OSVR_RM_USE_OPENGLES20
             GLuint VAO;
+#endif
             GLuint vertexBuffer;
             GLuint indexBuffer;
             std::vector<DistortionVertex> vertices;


### PR DESCRIPTION
Needed to make OpenGL work with contexts 3.3 and higher on some platforms.
Re-did the way VAO is removed, so that it is only removed on GLES 2.0 builds.