### PR TITLE
Switched from Log.h to Logger.h in RenderManager.h include.  The othe…

### DIFF
--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -37,7 +37,7 @@ Russ Taylor <russ@sensics.com>
 #include <osvr/ClientKit/ContextC.h>
 #include <osvr/ClientKit/InterfaceC.h>
 #include <osvr/Util/TimeValueC.h>
-#include <osvr/Util/Log.h>
+#include <osvr/Util/Logger.h>
 
 // Standard includes
 #include <vector>


### PR DESCRIPTION
…r files all had this different one and, even though the code compiles either way, the Jenkins build is failing with the Log.h so we'll try this one instead.