### PR TITLE
Add FOVE PNP ID to direct mode vendor list

### DIFF
--- a/osvr/RenderKit/DirectModeVendors.h
+++ b/osvr/RenderKit/DirectModeVendors.h
@@ -239,6 +239,7 @@ namespace renderkit {
             Vendor{"TSB", "VRGate"},
             Vendor{"VRV", "Vrvana"},
             Vendor{"TVR", "TotalVision"},
+            Vendor{"FOV", "FOVE"},
             /* add new vendors here - keep grouped by display descriptor vendor */
         };
         return vendors;


### PR DESCRIPTION
Adds the FOVE HMD display to the list of direct mode vendors per the documentation at:
https://github.com/OSVR/OSVR-Docs/blob/master/Extending-OSVR/AddingHMD.md