### PR TITLE
Stabilize timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ set (RenderManager_SOURCES
 	osvr/RenderKit/DistortionMesh.h
 	osvr/RenderKit/Float2.h
 	osvr/RenderKit/PoseStateCaching.h
+	osvr/RenderKit/DeltaQuatDeadReckoning.h
 )
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set (RenderManager_SOURCES
 	osvr/RenderKit/ComputeDistortionMesh.h
 	osvr/RenderKit/DistortionMesh.h
 	osvr/RenderKit/Float2.h
+	osvr/RenderKit/PoseStateCaching.h
 )
 
 if (WIN32)

--- a/osvr/RenderKit/DeltaQuatDeadReckoning.h
+++ b/osvr/RenderKit/DeltaQuatDeadReckoning.h
@@ -1,0 +1,63 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_DeltaQuatDeadReckoning_h_GUID_6BFD4A2F_F612_4EB6_7A69_05EC20C6D9AF
+#define INCLUDED_DeltaQuatDeadReckoning_h_GUID_6BFD4A2F_F612_4EB6_7A69_05EC20C6D9AF
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+#include <osvr/Util/EigenCoreGeometry.h>
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+    inline Eigen::Quaterniond applyQuatDeadReckoning(Eigen::Quaterniond const& initialOrientation, double angVelDt,
+                                                     Eigen::Quaterniond const& velocityDeltaQuat,
+                                                     double predictionDistance) {
+        Eigen::Quaterniond ret = initialOrientation;
+        // Determine the number of integer multiples of our deltaquat needed.
+        int multiples = static_cast<int>(predictionDistance / angVelDt);
+
+        // Determine the fractional (slerp) portion to apply after that.
+        auto predictionRemainder = predictionDistance - (multiples * angVelDt);
+        auto remainderAsFractionOfDt = predictionRemainder / angVelDt;
+
+        Eigen::Quaterniond fractionalDeltaQuat =
+            Eigen::Quaterniond::Identity().slerp(remainderAsFractionOfDt, velocityDeltaQuat);
+
+        // Actually perform the application of the prediction.
+        for (int i = 0; i < multiples; ++i) {
+            ret = velocityDeltaQuat * ret;
+        }
+        ret = fractionalDeltaQuat * ret;
+        return ret;
+    }
+} // namespace util
+} // namespace osvr
+
+#endif // INCLUDED_DeltaQuatDeadReckoning_h_GUID_6BFD4A2F_F612_4EB6_7A69_05EC20C6D9AF

--- a/osvr/RenderKit/PoseStateCaching.h
+++ b/osvr/RenderKit/PoseStateCaching.h
@@ -1,0 +1,114 @@
+/** @file
+    @brief Header
+
+    @date 2017
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2017 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_PoseStateCaching_h_GUID_0424A36E_4123_45A3_6DB8_3A6E4B90665B
+#define INCLUDED_PoseStateCaching_h_GUID_0424A36E_4123_45A3_6DB8_3A6E4B90665B
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+#include <osvr/ClientKit/ContextC.h>
+#include <osvr/ClientKit/Interface.h>
+#include <osvr/Util/TimeValue.h>
+#include <osvr/Util/Pose3C.h>
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace renderkit {
+    /// A class that handles stashing poses with optionally overridden timestamps.
+    ///
+    /// The associated client context must outlive it.
+    class PoseStateCaching {
+      public:
+        /// Constructor, taking a client context, semantic path, and a value indicating whether (true) or not (false) to
+        /// override timestamps coming with the reports by the timestamp at the time the callback is invoked.
+        PoseStateCaching(OSVR_ClientContext clientContext, const char path[], bool overrideTime)
+            : ctx_(clientContext), overrideTime_(overrideTime) {
+            osvrClientGetInterface(ctx_, path, &iface_);
+            if (!iface_) {
+                return;
+            }
+            osvrRegisterPoseCallback(iface_, &handleReport, this);
+        }
+
+        /// Destructor: cleans up the client interface object.
+        ~PoseStateCaching() {
+            if (ctx_ && iface_) {
+                osvrClientFreeInterface(ctx_, iface_);
+                ctx_ = nullptr;
+                iface_ = nullptr;
+            }
+        }
+
+        /// Non-copyable.
+        PoseStateCaching(PoseStateCaching const&) = delete;
+        /// Non-assignable.
+        PoseStateCaching& operator=(PoseStateCaching const&) = delete;
+
+        /// Indicates whether this object has observed a pose report yet.
+        bool hasReport() const { return hasPose_; }
+
+        /// Retrieve the last report, if one exists.
+        /// If none exists, out params are unchanged.
+        ///
+        /// @param [out] tv Timestamp associated with pose.
+        /// @param [out] pose The pose itself.
+        ///
+        /// @return true if there was a report observed and returned in the out params.
+        bool getLastReport(util::time::TimeValue& tv, OSVR_Pose3& pose) const {
+            if (!hasPose_) {
+                return false;
+            }
+
+            tv = lastTimestamp_;
+            pose = pose_;
+            return true;
+        }
+
+      private:
+        static void handleReport(void* userdata, const struct OSVR_TimeValue* timestamp,
+                                 const struct OSVR_PoseReport* report) {
+            auto self = static_cast<PoseStateCaching*>(userdata);
+            self->hasPose_ = true;
+            self->pose_ = report->pose;
+            if (self->overrideTime_) {
+                osvrTimeValueGetNow(&self->lastTimestamp_);
+            } else {
+                self->lastTimestamp_ = *timestamp;
+            }
+        }
+        OSVR_ClientContext ctx_;
+        bool overrideTime_;
+        OSVR_ClientInterface iface_ = nullptr;
+        bool hasPose_ = false;
+        util::time::TimeValue lastTimestamp_;
+        OSVR_Pose3 pose_;
+    };
+
+} // namespace renderkit
+} // namespace osvr
+#endif // INCLUDED_PoseStateCaching_h_GUID_0424A36E_4123_45A3_6DB8_3A6E4B90665B

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -58,6 +58,8 @@ namespace sensics {
 
 namespace osvr {
 namespace renderkit {
+    // forward declaration to avoid dragging in dependencies.
+    class PoseStateCaching;
 
     //=========================================================================
     // Handles optimizing rendering given a description of the desired rendering
@@ -1158,6 +1160,12 @@ namespace renderkit {
       protected:
         /// Logger to use for writing information, warning, and errors.
         util::log::LoggerPtr m_log;
+
+        bool hasHeadPose() const;
+        bool getLastHeadPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const;
+
+      private:
+        std::unique_ptr<PoseStateCaching> m_headPoseCache;
     };
 
     //=========================================================================

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -889,6 +889,7 @@ namespace renderkit {
                     // Nothing to do here.
                     break;
                 }
+                /// @todo do we want to make this effectively modulo 360?
 
                 /// Pass rotate_pixels_degrees
                 PresentEyeParameters p;
@@ -1167,6 +1168,7 @@ namespace renderkit {
         // Incorporate pitch_tilt (degrees, positive is downwards)
         // We assume that this results in a shearing of the image that leaves
         // the plane of the screen the same.
+        /// @todo in this case how would that differ from a non-0.5 yCOP?
         auto pitchTilt = m_params.m_displayConfiguration->getPitchTilt();
         if (pitchTilt != 0 * util::radians) {
             /// @todo
@@ -1197,10 +1199,8 @@ namespace renderkit {
         }
 
         /// @todo Figure out interactions between the above shifts and
-        /// distortions
-        /// and make sure to do them in the right order, or to adjust as needed
-        /// to
-        /// make them consistent when they are composed.
+        /// distortions and make sure to do them in the right order, or to adjust as needed
+        /// to make them consistent when they are composed.
 
         // Set the values in the projection matrix
         projection.left = left;
@@ -1480,6 +1480,7 @@ namespace renderkit {
         // right eyes.  We further assume that head space is between
         // the two eyes.  If the display descriptor wants us to swap
         // eyes, we do so by inverting the offset for each eye.
+        /// @todo dealing with eye tracking here or mono displays
         q_xyz_quat_type q_headFromRotatedEye;
         makeIdentity(q_headFromRotatedEye);
         if (whichEye % 2 == 0) {
@@ -1651,8 +1652,7 @@ namespace renderkit {
             // Scale the coordinates in X and Y so that they match the width and
             // height of a window at the specified distance from the origin.
             // We divide by the near clip distance to make the result match that
-            // at
-            // a unit distance and then multiply by the assumed depth.
+            // at a unit distance and then multiply by the assumed depth.
             float xScale = static_cast<float>(
                 (usedRenderInfo[eye].projection.right -
                  usedRenderInfo[eye].projection.left) /
@@ -1664,15 +1664,12 @@ namespace renderkit {
 
             // Compute the translation to use during forward transform.
             // Translate the points so that their center lies in the middle of
-            // the
-            // view frustum pushed out to the specified distance from the
+            // the view frustum pushed out to the specified distance from the
             // origin.
             // We take the mean coordinate of the two edges as the center that
-            // is
-            // to be moved to, and we move the space origin to there.
+            // is to be moved to, and we move the space origin to there.
             // We divide by the near clip distance to make the result match that
-            // at
-            // a unit distance and then multiply by the assumed depth.
+            // at a unit distance and then multiply by the assumed depth.
             // This assumes the default r texture coordinate of 0.
             float xTrans = static_cast<float>(
                 (usedRenderInfo[eye].projection.right +
@@ -1782,10 +1779,8 @@ namespace renderkit {
     }
 
     bool RenderManager::ComputeDisplayOrientationMatrix(
-        float rotateDegrees //< Rotation in degrees around Z
-        ,
-        bool flipInY //< Flip in Y after rotating?
-        ,
+        float rotateDegrees, //< Rotation in degrees around Z
+        bool flipInY, //< Flip in Y after rotating?
         matrix16& outMatrix //< Matrix to use.
         ) {
         // NOTE: These operations occur from the right to the left, so later

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -32,6 +32,7 @@ Russ Taylor <russ@sensics.com>
 #include "osvr_display_configuration.h"
 #include "DirectModeVendors.h"
 #include "CleanPNPIDString.h"
+#include "PoseStateCaching.h"
 
 #ifdef RM_USE_D3D11
 #include "RenderManagerD3D.h"
@@ -290,6 +291,9 @@ namespace renderkit {
         /// @todo Clone the passed-in context rather than creating our own, when
         // this function is added to Core.
         m_context = osvrClientInit("com.osvr.renderManager");
+
+        /// Start watching for head poses.
+        m_headPoseCache.reset(new PoseStateCaching(m_context, "/me/head", p.m_clientPredictionLocalTimeOverride));
 
         // Initialize all of the variables that don't have to be done in the
         // list above, so we don't get warnings about out-of-order
@@ -1510,8 +1514,7 @@ namespace renderkit {
             /// DO NOT update the client here, so that we're using the
             /// same state for all eyes.
             OSVR_TimeValue timestamp;
-            if (osvrGetPoseState(m_roomFromHeadInterface, &timestamp,
-                                 &m_roomFromHead) == OSVR_RETURN_FAILURE) {
+            if (!m_headPoseCache || !m_headPoseCache->getLastReport(timestamp, m_roomFromHead)) {
                 // This it not an error -- they may have put in an invalid
                 // state name for the head; we just ignore that case.
             }
@@ -1529,16 +1532,12 @@ namespace renderkit {
                   (timing.timeUntilNextPresentRequired.microseconds / 1e3f);
               }
 
-              // Adjust the time at which the most-recent tracking info was
-              // set based on whether we're supposed to override it with "now".
-              // If not, find out how long ago it was.
+              // Find out how long ago this tracker info was found.
               float msSinceTrackerReport = 0;
-              if (!m_params.m_clientPredictionLocalTimeOverride) {
-                OSVR_TimeValue now;
-                osvrTimeValueGetNow(&now);
-                msSinceTrackerReport = static_cast<float>(
-                  osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3
-                  );
+              {
+                  OSVR_TimeValue now;
+                  osvrTimeValueGetNow(&now);
+                  msSinceTrackerReport = static_cast<float>(osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3);
               }
 
               // The delay before rendering for each
@@ -1558,10 +1557,11 @@ namespace renderkit {
               OSVR_VelocityState vel;
               vel.linearVelocityValid = false;
               vel.angularVelocityValid = false;
-              if (osvrGetVelocityState(m_roomFromHeadInterface, &timestamp,
-                  &vel) != OSVR_RETURN_SUCCESS) {
-                // We're okay with failure here, we just use a zero
-                // velocity to predict.
+              if (osvrGetVelocityState(m_roomFromHeadInterface, &timestamp, &vel) != OSVR_RETURN_SUCCESS) {
+                  // We're okay with failure here, we just use a zero
+                  // velocity to predict.
+                  // Using normal get state calls here because we're effectively
+                  // throwing away the returned timestamp for this data.
               }
 
               // Predict the future pose of the head based on the velocity
@@ -1789,6 +1789,20 @@ namespace renderkit {
             Eigen::Projective3f(translate * scale).matrix();
 
         return true;
+    }
+
+    bool RenderManager::hasHeadPose() const {
+        if (!m_headPoseCache) {
+            return false;
+        }
+        return m_headPoseCache->hasReport();
+    }
+
+    bool RenderManager::getLastHeadPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const {
+        if (!m_headPoseCache) {
+            return false;
+        }
+        return m_headPoseCache->getLastReport(tv, pose);
     }
 
     static double pointDistance(double x1, double y1, double x2, double y2) {

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -21,6 +21,10 @@ set(IGNORED_HEADERS
         RenderKit/NDA/OSVR-RenderManager-Sensics/RenderManagerSensicsDS_D3D11.h
 )
 
+add_library(eigen_interface INTERFACE)
+target_include_directories(eigen_interface INTERFACE ${EIGEN3_INCLUDE_DIR})
+set(LIBRARIES_RenderKit_DeltaQuatDeadReckoning eigen_interface)
+
 # Special cases
 if (NOT OSVRRM_HAVE_D3D11_SUPPORT)
 	list(APPEND IGNORED_HEADERS


### PR DESCRIPTION
This improves the method for obtaining pose state and reliably predicting pose ahead to a given point in time, in part by making the code paths equivalent regardless of whether you have the timestamp override turned on or not.  Code I had worked on a while ago, just hadn't submitted it for PR despite using it locally.