### PR TITLE
Extended mode timing for d3d11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ if (RM_USE_SENSICS)
 		endif()
 endif()
 if (WIN32)
-	target_link_libraries(osvrRenderManager PRIVATE D3D11)
+	target_link_libraries(osvrRenderManager PRIVATE D3D11 Dwmapi)
 endif()
 
 set(LIBNAME_FULL osvrRenderManager)

--- a/examples/RenderManagerD3DExample3D.cpp
+++ b/examples/RenderManagerD3DExample3D.cpp
@@ -428,6 +428,14 @@ int main(int argc, char* argv[]) {
                       << std::endl;
             start = end;
             count = 0;
+
+            // Sample the render-timing info and report its values as well.
+            osvr::renderkit::RenderTimingInfo info;
+            render->GetTimingInfo(0, info);
+            std::cout << "Renderer estimates refresh rate at " <<
+              1.0e6 / (info.hardwareDisplayInterval.microseconds)
+              << " with " << info.timeSincelastVerticalRetrace.microseconds / 1e3
+              << "ms since last render" << std::endl;
         }
         count++;
     }

--- a/examples/RenderManagerD3DExample3D.cpp
+++ b/examples/RenderManagerD3DExample3D.cpp
@@ -432,10 +432,12 @@ int main(int argc, char* argv[]) {
             // Sample the render-timing info and report its values as well.
             osvr::renderkit::RenderTimingInfo info;
             render->GetTimingInfo(0, info);
-            std::cout << "Renderer estimates refresh rate at " <<
+            std::cout << "Renderer reports refresh rate at " <<
               1.0e6 / (info.hardwareDisplayInterval.microseconds)
               << " with " << info.timeSincelastVerticalRetrace.microseconds / 1e3
-              << "ms since last render" << std::endl;
+              << "ms since last retrace"
+              << " and " << info.timeUntilNextPresentRequired.microseconds / 1e3
+              << "ms until present is required to hit the next" << std::endl;
         }
         count++;
     }

--- a/osvr/RenderKit/RenderManagerD3D.h
+++ b/osvr/RenderKit/RenderManagerD3D.h
@@ -37,6 +37,9 @@ namespace renderkit {
         // Opens the D3D renderer we're going to use.
         OpenResults OpenDisplay() override;
 
+        bool OSVR_RENDERMANAGER_EXPORT
+          GetTimingInfo(size_t whichEye, RenderTimingInfo& info) override;
+
       protected:
         /// Construct a D3D RenderManager.
         RenderManagerD3D11(
@@ -55,8 +58,19 @@ namespace renderkit {
                 nullptr; ///< Pointer to render target texture
             ID3D11RenderTargetView* m_renderTargetView =
                 nullptr; ///< Pointer to our render target view
+
+            /// Size and timing info
+            DXGI_RATIONAL m_refreshRate;
         };
         std::vector<DisplayInfo> m_displays;
+
+        //===================================================================
+        // Member variables and threads needed to do our timing.
+
+        /// Time of the most-recent presentation that we have an accurate
+        /// measurement of.  In some cases, this will be the most-recent
+        /// actual surface present.  In other cases, it may be far in the past.
+        struct timeval m_earlierPresentTime = {};
 
         //===================================================================
         // Overloaded render functions from the base class.

--- a/osvr/RenderKit/RenderManagerD3D.h
+++ b/osvr/RenderKit/RenderManagerD3D.h
@@ -58,9 +58,6 @@ namespace renderkit {
                 nullptr; ///< Pointer to render target texture
             ID3D11RenderTargetView* m_renderTargetView =
                 nullptr; ///< Pointer to our render target view
-
-            /// Size and timing info
-            DXGI_RATIONAL m_refreshRate;
         };
         std::vector<DisplayInfo> m_displays;
 

--- a/osvr/RenderKit/RenderManagerD3D.h
+++ b/osvr/RenderKit/RenderManagerD3D.h
@@ -65,14 +65,6 @@ namespace renderkit {
         std::vector<DisplayInfo> m_displays;
 
         //===================================================================
-        // Member variables and threads needed to do our timing.
-
-        /// Time of the most-recent presentation that we have an accurate
-        /// measurement of.  In some cases, this will be the most-recent
-        /// actual surface present.  In other cases, it may be far in the past.
-        struct timeval m_earlierPresentTime = {};
-
-        //===================================================================
         // Overloaded render functions from the base class.
         bool RenderFrameInitialize() override { return true; }
         bool RenderDisplayInitialize(size_t display) override { return true; }


### PR DESCRIPTION
Implements (and then re-implements in a better way) render timing info in D3D11 extended mode.