### PR TITLE
Delete the pose cache before destroying the context to avoid seg faul…

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -435,6 +435,10 @@ namespace renderkit {
                                  cb.m_userData);
         }
 
+		// Destroy our head-pose cache object before we shut down our
+		// context to avoid seg fault.
+		m_headPoseCache.reset(nullptr);
+
         // Close our roomFromHeadInterface
         osvrClientFreeInterface(m_context, m_roomFromHeadInterface);
 

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -435,9 +435,9 @@ namespace renderkit {
                                  cb.m_userData);
         }
 
-		// Destroy our head-pose cache object before we shut down our
-		// context to avoid seg fault.
-		m_headPoseCache.reset(nullptr);
+        // Destroy our head-pose cache object before we shut down our
+        // context to avoid seg fault.
+        m_headPoseCache.reset(nullptr);
 
         // Close our roomFromHeadInterface
         osvrClientFreeInterface(m_context, m_roomFromHeadInterface);

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -437,7 +437,7 @@ namespace renderkit {
 
         // Destroy our head-pose cache object before we shut down our
         // context to avoid seg fault.
-        m_headPoseCache.reset(nullptr);
+        m_headPoseCache.reset();
 
         // Close our roomFromHeadInterface
         osvrClientFreeInterface(m_context, m_roomFromHeadInterface);


### PR DESCRIPTION
…t in debug mode.

Fixes issue https://github.com/sensics/OSVR-RenderManager/issues/327 which should be closed once this has been merged.