### PR TITLE
Added missing public header files to the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,9 +370,12 @@ set (RenderManager_PUBLIC_HEADERS
 	osvr/RenderKit/RenderManager.h
 	osvr/RenderKit/RenderManagerD3DBase.h
 	osvr/RenderKit/RenderManagerC.h
+    osvr/RenderKit/RenderManagerD3D11.h
 	osvr/RenderKit/RenderManagerD3D11C.h
+    osvr/RenderKit/RenderManagerOpenGL.h
 	osvr/RenderKit/RenderManagerOpenGLC.h
 	osvr/RenderKit/RenderManagerOpenGLVersion.h
+    osvr/RenderKit/RenderManagerD3DOpenGL.h
 	osvr/RenderKit/GraphicsLibraryD3D11.h
 	osvr/RenderKit/GraphicsLibraryOpenGL.h
 	osvr/RenderKit/MonoPointMeshTypes.h


### PR DESCRIPTION
Was missing OpenGL and D3D C++ header files.  Added them to so that the osvr::RenderKit::RenderManager can be static_casted into the underlying type, if it's known in advance.

Covers issue #329 