### PR TITLE
Linux and macOS tweaks

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -37,6 +37,12 @@ Russ Taylor <russ@sensics.com>
 #ifdef RM_USE_D3D11
 #include "RenderManagerD3D.h"
 #include "RenderManagerD3D11ATW.h"
+#else
+namespace osvr {
+namespace renderkit {
+    class RenderManagerD3D11Base : public RenderManager { };
+} // end namespace renderkit
+} // end namespace osvr
 #endif
 
 #ifdef RM_USE_NVIDIA_DIRECT_D3D11

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -213,7 +213,7 @@ namespace renderkit {
                          OSVR_ProjectionMatrix projection ///< Projection to use
                          ) override;
         bool RenderEyeFinalize(size_t eye) override { return true; }
-		bool RenderDisplayFinalize(size_t display);
+        bool RenderDisplayFinalize(size_t display) override;
         bool RenderFrameFinalize() override;
 
         bool PresentFrameInitialize() override { return true; }


### PR DESCRIPTION
Fixes [this compiler error](https://github.com/sensics/OSVR-RenderManager/pull/330#issuecomment-320381229) by providing a dummy `RenderManagerD3D11Base` class for non-D3D systems.