### PR TITLE
Fixes

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -1620,7 +1620,7 @@ namespace renderkit {
         // approach works for OpenGL.
         float flipYScale = 1.0f;
         bool doTranspose = false;
-        if (dynamic_cast<RenderManagerD3D11Base*>(this)) {
+        if (m_params.m_renderLibrary.find("Direct3D") != std::string::npos) {
           flipYScale = -1.0f;
           doTranspose = true;
         }

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -213,7 +213,7 @@ namespace renderkit {
                          OSVR_ProjectionMatrix projection ///< Projection to use
                          ) override;
         bool RenderEyeFinalize(size_t eye) override { return true; }
-		bool RenderDisplayFinalize(size_t display);
+        bool RenderDisplayFinalize(size_t display) override;
         bool RenderFrameFinalize() override;
 
         bool PresentFrameInitialize() override { return true; }


### PR DESCRIPTION
Switches back to a slower but portable way to determine if we're a Direct3D renderer.  Can't type-cast to a class that is not defined...

Also added override to avoid compiler warning (and to clarify) on a method that is overriding a base-class method.