### PR TITLE
Custom gl timing info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 *.msi
 installer/osvrRenderManager-cache/*
 *.TMP
+.vscode/

--- a/examples/RenderManagerOpenGLQt5Example.cpp
+++ b/examples/RenderManagerOpenGLQt5Example.cpp
@@ -112,7 +112,9 @@ class Qt5ToolkitImpl {
     static OSVR_CBool getDisplaySizeOverrideImpl(void* data, size_t display, int* width, int* height) {
         return ((Qt5ToolkitImpl*)data)->getDisplaySizeOverride(display, width, height);
     }
-
+    static OSVR_CBool getRenderTimingInfoImpl(void* data, size_t display, size_t whichEye, OSVR_RenderTimingInfo* renderTimingInfoOut) {
+        return ((Qt5ToolkitImpl*)data)->getRenderTimingInfo(display, whichEye, renderTimingInfoOut);
+    }
     QList<QGLWidget*> glwidgets;
     QList<QWidget*> widgets;
 
@@ -131,6 +133,7 @@ class Qt5ToolkitImpl {
         toolkit.setVerticalSync = setVerticalSyncImpl;
         toolkit.handleEvents = handleEventsImpl;
         toolkit.getDisplaySizeOverride = getDisplaySizeOverrideImpl;
+        toolkit.getRenderTimingInfo = getRenderTimingInfoImpl;
     }
 
     ~Qt5ToolkitImpl() {
@@ -207,6 +210,10 @@ class Qt5ToolkitImpl {
     }
     bool getDisplaySizeOverride(size_t display, int* width, int* height) {
         // we don't override the display. Use default behavior.
+        return false;
+    }
+    bool getRenderTimingInfo(size_t display, size_t whichEye, OSVR_RenderTimingInfo* renderTimingInfoOut) {
+        // @todo implement for Qt? if possible?
         return false;
     }
 };

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -26,6 +26,7 @@ Russ Taylor <russ@sensics.com>
 
 // Internal Includes
 #include <osvr/RenderKit/Export.h>
+#include <osvr/RenderKit/RenderManagerC.h>
 #include "osvr_display_configuration.h"
 #include "RenderKitGraphicsTransforms.h"
 #include "DistortionParameters.h"
@@ -112,23 +113,6 @@ namespace renderkit {
         RenderBufferOpenGL*
             OpenGL; ///< #include <osvr/RenderKit/GraphicsLibraryOpenGL.h>
     };
-
-    /// @brief Timing information about the rendering system
-    ///
-    /// Structure that holds timing information about the system.
-    /// Each of these times will have the value (0,0) if they are
-    /// not available from a particular RenderManager.
-    typedef struct {
-        /// Time between refresh of display device
-        OSVR_TimeValue hardwareDisplayInterval;
-
-        /// Time since the last retrace ended (the last presentation)
-        OSVR_TimeValue timeSincelastVerticalRetrace;
-
-        /// How long until the app must send images to RenderManager
-        /// to display before the next frame is presented.
-        OSVR_TimeValue timeUntilNextPresentRequired;
-    } RenderTimingInfo;
 
     /// @brief Simple structure for representing a float based RGB color
     typedef struct {
@@ -508,7 +492,7 @@ namespace renderkit {
         virtual bool OSVR_RENDERMANAGER_EXPORT GetTimingInfo(
                 // @todo Each display has a potentially different timing
                 size_t whichEye, //!< Each eye has a potentially different timing
-                RenderTimingInfo& info //!< Info that is returned
+                OSVR_RenderTimingInfo& info //!< Info that is returned
             ) {
                 return false;
         }

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -780,7 +780,7 @@ namespace renderkit {
                 // We use the first eye in the system and assume that all of the
                 // others are synchronized to it.
                 // @todo Consider what happens for non-genlocked displays
-                RenderTimingInfo info;
+                OSVR_RenderTimingInfo info;
                 if (GetTimingInfo(0, info)) {
                     OSVR_TimeValue nextRetrace = info.hardwareDisplayInterval;
                     osvrTimeValueDifference(&nextRetrace,
@@ -1503,7 +1503,7 @@ namespace renderkit {
               // Get information about how long we have until the next present.
               // If we can't get timing info, we just set its offset to 0.
               float msUntilPresent = 0;
-              RenderTimingInfo timing;
+              OSVR_RenderTimingInfo timing;
               if (GetTimingInfo(whichEye, timing)) {
                 msUntilPresent +=
                   (timing.timeUntilNextPresentRequired.seconds * 1e3f) +

--- a/osvr/RenderKit/RenderManagerC.h
+++ b/osvr/RenderKit/RenderManagerC.h
@@ -37,6 +37,7 @@
 #include <osvr/Util/ClientReportTypesC.h>
 #include <osvr/Util/ClientOpaqueTypesC.h>
 #include <osvr/Util/BoolC.h>
+#include <osvr/Util/TimeValueC.h>
 
 /* Library/third-party includes */
 /* none */
@@ -99,7 +100,22 @@ typedef enum {
     OSVR_OPEN_STATUS_COMPLETE
 } OSVR_OpenStatus;
 
-// @todo OSVR_RenderTimingInfo
+    /// @brief Timing information about the rendering system
+    ///
+    /// Structure that holds timing information about the system.
+    /// Each of these times will have the value (0,0) if they are
+    /// not available from a particular RenderManager.
+typedef struct OSVR_RenderTimingInfo {
+    /// Time between refresh of display device
+    OSVR_TimeValue hardwareDisplayInterval;
+
+    /// Time since the last retrace ended (the last presentation)
+    OSVR_TimeValue timeSincelastVerticalRetrace;
+
+    /// How long until the app must send images to RenderManager
+    /// to display before the next frame is presented.
+    OSVR_TimeValue timeUntilNextPresentRequired;
+} OSVR_RenderTimingInfo;
 
 OSVR_RENDERMANAGER_EXPORT OSVR_ReturnCode
 osvrDestroyRenderManager(OSVR_RenderManager renderManager);

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -162,7 +162,7 @@ namespace osvr {
             // entries will not be as useful, given that ATW is being used to
             // interpolate, but they are also returned.
             bool OSVR_RENDERMANAGER_EXPORT
-              GetTimingInfo(size_t whichEye, RenderTimingInfo& info) override {
+              GetTimingInfo(size_t whichEye, OSVR_RenderTimingInfo& info) override {
                 return mRenderManager->GetTimingInfo(whichEye, info);
               };
 
@@ -312,7 +312,7 @@ namespace osvr {
                     // that are not gen-locked.
                     // @todo Consider making a function that both the RenderManagerBase.cpp
                     // and this code calls to check if we're within range.
-                    osvr::renderkit::RenderTimingInfo timing;
+                    OSVR_RenderTimingInfo timing;
                     double expectedFrameInterval = -1;
                     if (mRenderManager->GetTimingInfo(0, timing)) {
 

--- a/osvr/RenderKit/RenderManagerD3DOpenGL.h
+++ b/osvr/RenderKit/RenderManagerD3DOpenGL.h
@@ -55,7 +55,7 @@ namespace renderkit {
 
         // Harnesses a D3D DirectMode renderer to do timing.
         bool OSVR_RENDERMANAGER_EXPORT
-        GetTimingInfo(size_t whichEye, RenderTimingInfo& info) override {
+        GetTimingInfo(size_t whichEye, OSVR_RenderTimingInfo& info) override {
             return m_D3D11Renderer->GetTimingInfo(whichEye, info);
         }
 

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -470,13 +470,7 @@ namespace renderkit {
       if(!m_toolkit.getRenderTimingInfo) {
         return false;
       }
-      OSVR_RenderTimingInfo renderTimingInfo = {0};
-      if(!m_toolkit.getRenderTimingInfo(m_toolkit.data, 0, whichEye, &renderTimingInfo)) {
-        return false; // don't modify info if toolkit returns false
-      }
-      info.hardwareDisplayInterval = renderTimingInfo.hardwareDisplayInterval;
-      info.timeSincelastVerticalRetrace = renderTimingInfo.timeSincelastVerticalRetrace;
-      info.timeUntilNextPresentRequired = renderTimingInfo.timeUntilNextPresentRequired;
+      return m_toolkit.getRenderTimingInfo(m_toolkit.data, 0, whichEye, &info);
     }
 
     bool RenderManagerOpenGL::RenderPathSetup() {

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -466,16 +466,17 @@ namespace renderkit {
         delete m_library.OpenGL;
     }
 
-    bool RenderManagerOpenGL::GetTimingInfo(size_t whichEye, RenderTimingInfo& info) {
-      if(m_toolkit.getRenderTimingInfo) {
-        OSVR_RenderTimingInfo renderTimingInfo;
-        bool ret = m_toolkit.getRenderTimingInfo(m_toolkit.data, 0, whichEye, &renderTimingInfo);
-        info.hardwareDisplayInterval = renderTimingInfo.hardwareDisplayInterval;
-        info.timeSincelastVerticalRetrace = renderTimingInfo.timeSincelastVerticalRetrace;
-        info.timeUntilNextPresentRequired = renderTimingInfo.timeUntilNextPresentRequired;
-        return ret;
+    bool RenderManagerOpenGL::GetTimingInfo(size_t whichEye, OSVR_RenderTimingInfo& info) {
+      if(!m_toolkit.getRenderTimingInfo) {
+        return false;
       }
-      return false;
+      OSVR_RenderTimingInfo renderTimingInfo = {0};
+      if(!m_toolkit.getRenderTimingInfo(m_toolkit.data, 0, whichEye, &renderTimingInfo)) {
+        return false; // don't modify info if toolkit returns false
+      }
+      info.hardwareDisplayInterval = renderTimingInfo.hardwareDisplayInterval;
+      info.timeSincelastVerticalRetrace = renderTimingInfo.timeSincelastVerticalRetrace;
+      info.timeUntilNextPresentRequired = renderTimingInfo.timeUntilNextPresentRequired;
     }
 
     bool RenderManagerOpenGL::RenderPathSetup() {

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -85,6 +85,9 @@ class SDLToolkitImpl {
   static OSVR_CBool getDisplaySizeOverrideImpl(void* data, size_t display, int* width, int* height) {
       return ((SDLToolkitImpl*)data)->getDisplaySizeOverride(display, width, height);
   }
+  static OSVR_CBool getRenderTimingInfoImpl(void* data, size_t display, size_t whichEye, OSVR_RenderTimingInfo* renderTimingInfoOut) {
+      return ((SDLToolkitImpl*)data)->getRenderTimingInfo(display, whichEye, renderTImingInfoOut);
+  }
 
   // Classes and structures needed to do our rendering.
   class DisplayInfo {
@@ -115,6 +118,7 @@ public:
     toolkit.handleEvents = handleEventsImpl;
     toolkit.getDisplayFrameBuffer = getDisplayFrameBufferImpl;
     toolkit.getDisplaySizeOverride = getDisplaySizeOverrideImpl;
+    toolkit.getRenderTimingInfo = getRenderTimingInfoImpl;
   }
 
   ~SDLToolkitImpl() {
@@ -258,6 +262,11 @@ public:
 
   bool getDisplaySizeOverride(size_t display, int* width, int* height) {
       // we don't override the display. Use default behavior.
+      return false;
+  }
+
+  bool getRenderTimingInfo(size_t display, size_t whichEye, OSVR_RenderTimingInfo* renderTimingInfoOut) {
+      // @todo get render timing info from SDL?
       return false;
   }
 };
@@ -455,6 +464,18 @@ namespace renderkit {
         }
         delete m_buffers.OpenGL;
         delete m_library.OpenGL;
+    }
+
+    bool RenderManagerOpenGL::GetTimingInfo(size_t whichEye, RenderTimingInfo& info) {
+      if(m_toolkit.getRenderTimingInfo) {
+        OSVR_RenderTimingInfo renderTimingInfo;
+        bool ret = m_toolkit.getRenderTimingInfo(m_toolkit.data, 0, whichEye, &renderTimingInfo);
+        info.hardwareDisplayInterval = renderTimingInfo.hardwareDisplayInterval;
+        info.timeSincelastVerticalRetrace = renderTimingInfo.timeSincelastVerticalRetrace;
+        info.timeUntilNextPresentRequired = renderTimingInfo.timeUntilNextPresentRequired;
+        return ret;
+      }
+      return false;
     }
 
     bool RenderManagerOpenGL::RenderPathSetup() {

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -87,6 +87,8 @@ namespace renderkit {
         // Opens the D3D renderer we're going to use.
         OpenResults OpenDisplay() override;
 
+        bool OSVR_RENDERMANAGER_EXPORT GetTimingInfo(size_t whichEye, RenderTimingInfo& info) override;
+
       protected:
         /// Construct an OpenGL render manager.
         RenderManagerOpenGL(

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -87,7 +87,7 @@ namespace renderkit {
         // Opens the D3D renderer we're going to use.
         OpenResults OpenDisplay() override;
 
-        bool OSVR_RENDERMANAGER_EXPORT GetTimingInfo(size_t whichEye, RenderTimingInfo& info) override;
+        bool OSVR_RENDERMANAGER_EXPORT GetTimingInfo(size_t whichEye, OSVR_RenderTimingInfo& info) override;
 
       protected:
         /// Construct an OpenGL render manager.

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -81,18 +81,6 @@ typedef struct OSVR_OpenGLContextParams {
     OSVR_CBool visible;
 } OSVR_OpenGLContextParams;
 
-typedef struct OSVR_RenderTimingInfo {
-        /// Time between refresh of display device
-        OSVR_TimeValue hardwareDisplayInterval;
-
-        /// Time since the last retrace ended (the last presentation)
-        OSVR_TimeValue timeSincelastVerticalRetrace;
-
-        /// How long until the app must send images to RenderManager
-        /// to display before the next frame is presented.
-        OSVR_TimeValue timeUntilNextPresentRequired;
-} OSVR_RenderTimingInfo;
-
 typedef struct OSVR_OpenGLToolkitFunctions {
     // Should be set to sizeof(OSVR_OpenGLToolkitFunctions) to allow the library
     // to detect when the client was compiled against an older version which has

--- a/osvr/RenderKit/RenderManagerOpenGLC.h
+++ b/osvr/RenderKit/RenderManagerOpenGLC.h
@@ -31,6 +31,8 @@
 
 // Library/third-party includes
 #include <osvr/Util/PlatformConfig.h>
+#include <osvr/Util/TimeValueC.h>
+
 #if defined(_WIN32)
 #include <windows.h>
 #endif
@@ -79,6 +81,18 @@ typedef struct OSVR_OpenGLContextParams {
     OSVR_CBool visible;
 } OSVR_OpenGLContextParams;
 
+typedef struct OSVR_RenderTimingInfo {
+        /// Time between refresh of display device
+        OSVR_TimeValue hardwareDisplayInterval;
+
+        /// Time since the last retrace ended (the last presentation)
+        OSVR_TimeValue timeSincelastVerticalRetrace;
+
+        /// How long until the app must send images to RenderManager
+        /// to display before the next frame is presented.
+        OSVR_TimeValue timeUntilNextPresentRequired;
+} OSVR_RenderTimingInfo;
+
 typedef struct OSVR_OpenGLToolkitFunctions {
     // Should be set to sizeof(OSVR_OpenGLToolkitFunctions) to allow the library
     // to detect when the client was compiled against an older version which has
@@ -101,6 +115,7 @@ typedef struct OSVR_OpenGLToolkitFunctions {
     OSVR_CBool (*handleEvents)(void* data);
     OSVR_CBool (*getDisplayFrameBuffer)(void* data, size_t display, GLuint* frameBufferOut);
     OSVR_CBool (*getDisplaySizeOverride)(void* data, size_t display, int* width, int* height);
+    OSVR_CBool (*getRenderTimingInfo)(void* data, size_t display, size_t whichEye, OSVR_RenderTimingInfo* renderTimingInfoOut);
 } OSVR_OpenGLToolkitFunctions;
 
 typedef struct OSVR_GraphicsLibraryOpenGL {


### PR DESCRIPTION
Adds an override to the OpenGL toolkit structure that allows applications to provide custom vsync timing information to RenderManager from a custom OpenGL window toolkit implementation (example SDL, Android View, Qt, etc...). No implementation is given for existing implementations - currently the SDL implementation which is the default on non-Android platforms, and the sample Qt implementation.