### PR TITLE
Reduce the floating-point resolution used in the OpenGL fragment shad…

### DIFF
--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -302,7 +302,7 @@ static const GLchar* distortionVertexShader =
 
 static const GLchar* distortionFragmentShader =
 "#version 100\n"
-"precision highp float;\n"
+"precision mediump float;\n"
 "uniform sampler2D tex;\n"
 "varying vec2 warpedCoordinateR;\n"
 "varying vec2 warpedCoordinateG;\n"


### PR DESCRIPTION
…er from high to medium precision for texture coordinates.

Will run on more systems and reduce the amount of work done when rendering.