### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Those who don't have access to the NDA repositories get using:
 ```
 git clone https://github.com/sensics/OSVR-RenderManager.git
 cd OSVR-RenderManager
-git submodule init vendor/vrpn
-git submodule update
+git submodule update --init --recursive vendor/vrpn
 ```
 
 Sensics internal users, who have access to the NDA repos, get using:


### PR DESCRIPTION
Clarifying how external users should initialize the repository by putting the whole command into one line.  This is in response to an issue that was filed from someone who missed the vendor/vrpn hiding at the end of the first line.