### PR TITLE
Nvidia atw updates

### DIFF
--- a/examples/RenderManagerD3DATWDoubleBufferExample.cpp
+++ b/examples/RenderManagerD3DATWDoubleBufferExample.cpp
@@ -40,6 +40,7 @@ Russ Taylor <russ@sensics.com>
 #include <iostream>
 #include <string>
 #include <chrono>
+#include <thread>
 #include <stdlib.h> // For exit()
 
 using namespace DirectX;
@@ -135,6 +136,8 @@ struct FrameInfo {
 };
 
 int main(int argc, char* argv[]) {
+	std::cout << "Render thread id: " << std::this_thread::get_id();
+
     // Parse the command line
     int delayMilliSeconds = 500;
     int realParams = 0;

--- a/examples/RenderManagerD3DATWDoubleBufferExample.cpp
+++ b/examples/RenderManagerD3DATWDoubleBufferExample.cpp
@@ -118,7 +118,9 @@ void RenderView(
 
     // draw room
     simpleShader.use(device, context, xm_projectionD3D, xm_viewD3D, identity);
-    roomCube.draw(device, context);
+	//for (size_t i = 0; i < 10000; i++) {
+		roomCube.draw(device, context);
+	//}
 }
 
 void Usage(std::string name) {
@@ -136,10 +138,10 @@ struct FrameInfo {
 };
 
 int main(int argc, char* argv[]) {
-	std::cout << "Render thread id: " << std::this_thread::get_id();
+	std::cout << "Render thread id: " << std::this_thread::get_id() << std::endl;
 
     // Parse the command line
-    int delayMilliSeconds = 500;
+    int delayMilliSeconds = 0;
     int realParams = 0;
     for (int i = 1; i < argc; i++) {
         if (argv[i][0] == '-') {

--- a/examples/RenderManagerD3DCAPIExample.cpp
+++ b/examples/RenderManagerD3DCAPIExample.cpp
@@ -128,7 +128,6 @@ void Usage(std::string name) {
 }
 
 int main(int argc, char* argv[]) {
-	SetThreadName((DWORD)-1, "RenderThread");
 	std::cout << "Render thread id: " << std::this_thread::get_id();
     // Parse the command line
     int realParams = 0;
@@ -276,8 +275,8 @@ int main(int argc, char* argv[]) {
 
         // Initialize a new render target texture description.
         D3D11_TEXTURE2D_DESC textureDesc = {};
-        textureDesc.Width = width;
-        textureDesc.Height = height;
+		textureDesc.Width = static_cast<UINT>(width);
+        textureDesc.Height = static_cast<UINT>(height);
         textureDesc.MipLevels = 1;
         textureDesc.ArraySize = 1;
         textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -333,8 +332,8 @@ int main(int argc, char* argv[]) {
         textureDescription.SampleDesc.Quality = 0;
         textureDescription.Usage = D3D11_USAGE_DEFAULT;
         textureDescription.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-        textureDescription.Width = width;
-        textureDescription.Height = height;
+        textureDescription.Width = static_cast<UINT>(width);
+        textureDescription.Height = static_cast<UINT>(height);
         textureDescription.MipLevels = 1;
         textureDescription.ArraySize = 1;
         textureDescription.CPUAccessFlags = 0;

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2335,7 +2335,7 @@ namespace renderkit {
                     // DirectMode interface as well.
                     if (p.m_asynchronousTimeWarp) {
                         RenderManager::ConstructorParameters pTemp = p;
-						pTemp.m_verticalSync = false;
+						pTemp.m_verticalSync = true;
 						pTemp.m_verticalSyncBlocksRendering = false;
 						pTemp.m_maxMSBeforeVsyncTimeWarp = 0;
 						pTemp.m_enableTimeWarp = true;

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2335,8 +2335,15 @@ namespace renderkit {
                     // DirectMode interface as well.
                     if (p.m_asynchronousTimeWarp) {
                         RenderManager::ConstructorParameters pTemp = p;
+						pTemp.m_verticalSync = false;
+						pTemp.m_verticalSyncBlocksRendering = false;
+						pTemp.m_maxMSBeforeVsyncTimeWarp = 0;
+						pTemp.m_enableTimeWarp = true;
+						pTemp.m_asynchronousTimeWarp = false;
                         pTemp.m_graphicsLibrary.D3D11 = nullptr;
+
                         auto wrappedRm = openRenderManagerDirectMode(contextParameter, pTemp);
+						wrappedRm->m_vsyncBlockAfterFrameBufferPresent = true;
                         ret.reset(new RenderManagerD3D11ATW(contextParameter, p, wrappedRm));
                     }
                     else {

--- a/osvr/RenderKit/RenderManagerD3D11ATW.h
+++ b/osvr/RenderKit/RenderManagerD3D11ATW.h
@@ -298,6 +298,7 @@ namespace osvr {
 
             void threadFunc() {
                 // Used to make sure we don't take too long to render
+				m_log->info() << "RenderManagerD3D11ATW::threadFunc thread id: " << std::this_thread::get_id() << std::endl;
                 struct timeval lastFrameTime = {};
                 bool quit = getQuit();
                 size_t iteration = 0;
@@ -370,6 +371,8 @@ namespace osvr {
                                 atwRenderBuffers.push_back(bufferInfoItr->second.atwBuffer);
                             }
 
+							//m_log->info() << "RenderManagerD3D11ATW::threadFunc: presenting frame to internal backend.";
+
                             // Send the rendered results to the screen, using the
                             // RenderInfo that was handed to us by the client the last
                             // time they gave us some images.
@@ -385,6 +388,8 @@ namespace osvr {
                                     setDoingOkay(false);
                                     mQuit = true;
                             }
+
+							//m_log->info() << "RenderManagerD3D11ATW::threadFunc: finished presenting frame to internal backend.";
 
                             struct timeval now;
                             vrpn_gettimeofday(&now, nullptr);

--- a/osvr/RenderKit/RenderManagerD3DBase.h
+++ b/osvr/RenderKit/RenderManagerD3DBase.h
@@ -93,6 +93,12 @@ namespace renderkit {
 
         bool m_displayOpen; ///< Has our display been opened?
 
+		/// Block until vsync after a framebuffer or direct mode present, even if
+		/// parameters say not to. This is used by the ATW wrapper to do a more
+		/// fine-grained blocking (no blocking before present, but yes blocking after)
+		/// TODO: Could this be added as a new parameter? Might be a breaking change if so.
+		bool m_vsyncBlockAfterFrameBufferPresent = false;
+
         /// The adapter, if and only if explicitly set.
         Microsoft::WRL::ComPtr<IDXGIAdapter> m_adapter;
 
@@ -208,6 +214,12 @@ namespace renderkit {
         friend class RenderManagerD3D11OpenGL;
         friend class RenderManagerD3D11ATW;
         friend class ::sensics::compositor::DisplayServerInterfaceD3D11Singleton;
+
+		// needed to access m_vsyncBlockAfterFrameBufferPresent from createRenderManager
+		// TODO: if this is added as a parameter (breaking change), then this isn't needed anymore and should be removed.
+		friend RenderManager* createRenderManager(OSVR_ClientContext contextParameter,
+			const std::string& renderLibraryName,
+			GraphicsLibrary graphicsLibrary);
     };
 
 } // namespace renderkit


### PR DESCRIPTION
 - default thread sleep for the ATW Double buffered sample set to 0 instead of 500.
 - added log lines to indicate thread ids of the render thread and the ATW thread to help debugging.
 - D3DCAPI example now uses double buffering and single render target for both eyes.
 - added client context timeout code for D3DCAPI example.
 - Added m_vsyncBlockAfterFrameBufferPresent field to D3D base class to control vsync blocking behavior. Used by ATW to block after the framebuffer present of the wrapped RenderManager instance but not before (which is handled by the ATW thread).
 - modified constructor params of the wrapped D3D11 RenderManager instance before constructing it and passing it to the D3D11 ATW backend.
 - Added a std::condition_variable to the D3D11 ATW backend and use it to block client Present until that frame is presented.