### PR TITLE
Uses /me/viewpoints/left and /me/viewpoints/right poses in ConstructModelView

### DIFF
--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -323,6 +323,10 @@ namespace renderkit {
                 nullptr; ///< Room space to insert
             const OSVR_PoseState* roomFromHeadReplace =
                 nullptr; ///< Overrides head space
+			const OSVR_PoseState* roomFromLeftViewpointReplace =
+				nullptr; ///< Overrides left viewpoint space
+			const OSVR_PoseState* roomFromRightViewpointReplace =
+				nullptr; ///< Overrides right viewpoint space
             double nearClipDistanceMeters = 0.1;
             double farClipDistanceMeters = 100.0;
             double IPDMeters = 0.063; ///< Inter-puppilary distance of the viewer
@@ -616,6 +620,8 @@ namespace renderkit {
                 m_displayConfiguration; ///< Display configuration
 
             std::string m_roomFromHeadName; ///< Transform to use for head space
+			std::string m_roomFromLeftViewpointName; ///< Transform to use for left eye space
+			std::string m_roomFromRightViewpointName; ///< Transform to use for right eye space
 
             /// Graphics library (device/context) to use instead of creating one
             /// if the pointer is non-NULL.  Note that the appropriate context
@@ -743,6 +749,11 @@ namespace renderkit {
         /// be checked for, but is sort of an error).
         OSVR_ClientInterface m_roomFromHeadInterface;
         OSVR_PoseState m_roomFromHead; ///< Transform to use for head space
+
+		OSVR_ClientInterface m_roomFromLeftViewpointInterface;
+		OSVR_ClientInterface m_roomFromRightViewpointInterface;
+		OSVR_PoseState m_roomFromLeftViewpoint; ///< Transform to use for left viewpoint
+		OSVR_PoseState m_roomFromRightViewpoint; ///< Transform to use for right viewpoint
 
         /// @brief Stores display callback information
         ///
@@ -1167,9 +1178,15 @@ namespace renderkit {
 
         bool hasHeadPose() const;
         bool getLastHeadPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const;
+		bool hasLeftViewpointPose() const;
+		bool hasRightViewpointPose() const;
+		bool getLastLeftViewpointPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const;
+		bool getLastRightViewpointPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const;
 
       private:
         std::unique_ptr<PoseStateCaching> m_headPoseCache;
+		std::unique_ptr<PoseStateCaching> m_leftViewpointPoseCache;
+		std::unique_ptr<PoseStateCaching> m_rightViewpointPoseCache;
     };
 
     //=========================================================================

--- a/osvr/RenderKit/RenderManager.h
+++ b/osvr/RenderKit/RenderManager.h
@@ -316,38 +316,35 @@ namespace renderkit {
         /// and Z pointing towards the back of the head, right-handed), send
         /// a pointer to a head transform.  This does not override any
         /// room transform, but will have the room appended.
-        class RenderParams {
-          public:
-            /// @brief Default constructor reads things from a display configuration.
-            /// @param [in] dc OSVRDisplayConfiguration to read values from.  If none
-            ///                is specified, it defaults to the default configuration.
-            RenderParams(OSVRDisplayConfiguration const &dc = OSVRDisplayConfiguration()) {
-              nearClipDistanceMeters = dc.getNearClipMeters();
-              farClipDistanceMeters = dc.getFarClipMeters();
-              IPDMeters = dc.getIPDMeters();
-            };
+		class RenderParams {
+		public:
+			/// @brief Default constructor reads things from a display configuration.
+			/// @param [in] dc OSVRDisplayConfiguration to read values from.  If none
+			///                is specified, it defaults to the default configuration.
+			RenderParams(OSVRDisplayConfiguration const &dc = OSVRDisplayConfiguration()) {
+				nearClipDistanceMeters = dc.getNearClipMeters();
+				farClipDistanceMeters = dc.getFarClipMeters();
+				IPDMeters = dc.getIPDMeters();
+			};
 
-            const OSVR_PoseState* worldFromRoomAppend =
-                nullptr; ///< Room space to insert
-            const OSVR_PoseState* roomFromHeadReplace =
-                nullptr; ///< Overrides head space
+			const OSVR_PoseState* worldFromRoomAppend =
+				nullptr; ///< Room space to insert
+			const OSVR_PoseState* roomFromHeadReplace =
+				nullptr; ///< Overrides head space
 			const OSVR_PoseState* roomFromLeftViewpointReplace =
 				nullptr; ///< Overrides left viewpoint space
 			const OSVR_PoseState* roomFromRightViewpointReplace =
 				nullptr; ///< Overrides right viewpoint space
-            double nearClipDistanceMeters = 0.1;
-            double farClipDistanceMeters = 100.0;
-            double IPDMeters = 0.063; ///< Inter-puppilary distance of the viewer
 
-            /// Gets the near and far clipping distances from the display configuration
-            /// in the default constructor.  Can be overridden.
-            double nearClipDistanceMeters;
-            double farClipDistanceMeters;
+			/// Gets the near and far clipping distances from the display configuration
+			/// in the default constructor.  Can be overridden.
+			double nearClipDistanceMeters;
+			double farClipDistanceMeters;
 
-            /// Gets the default IPD from the display configuration in the
-            /// default constructor.  Can be overridden.
-            double IPDMeters;
-        };
+			/// Gets the default IPD from the display configuration in the
+			/// default constructor.  Can be overridden.
+			double IPDMeters;
+		};
 
         /// @brief Render the scene with minimum latency.
         ///

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -333,13 +333,15 @@ namespace renderkit {
 		if (osvrClientGetInterface(m_context, leftEyeSpaceName.c_str(),
 			&m_roomFromLeftViewpointInterface) ==
 			OSVR_RETURN_FAILURE) {
-			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << leftEyeSpaceName;
+			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << leftEyeSpaceName
+                << ", basing view on head + IPD";
 		}
 		osvrPose3SetIdentity(&m_roomFromLeftViewpoint);
 		if (osvrClientGetInterface(m_context, rightEyeSpaceName.c_str(),
 			&m_roomFromRightViewpointInterface) ==
 			OSVR_RETURN_FAILURE) {
-			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << rightEyeSpaceName;
+			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << rightEyeSpaceName
+                << ", basing view on head + IPD";
 		}
 		osvrPose3SetIdentity(&m_roomFromRightViewpoint);
 

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -283,6 +283,9 @@ namespace renderkit {
 
         /// Start watching for head poses.
         m_headPoseCache.reset(new PoseStateCaching(m_context, "/me/head", p.m_clientPredictionLocalTimeOverride));
+		// Start watching for viewpoint poses.
+		m_leftViewpointPoseCache.reset(new PoseStateCaching(m_context, "/me/viewpoint/left", p.m_clientPredictionLocalTimeOverride));
+		m_rightViewpointPoseCache.reset(new PoseStateCaching(m_context, "/me/viewpoint/right", p.m_clientPredictionLocalTimeOverride));
 
         // Initialize all of the variables that don't have to be done in the
         // list above, so we don't get warnings about out-of-order
@@ -308,6 +311,15 @@ namespace renderkit {
             headSpaceName = p.m_roomFromHeadName;
         }
 
+		std::string leftEyeSpaceName = "/me/viewpoint/left";
+		if (p.m_roomFromLeftViewpointName.size() > 0) {
+			leftEyeSpaceName = p.m_roomFromLeftViewpointName;
+		}
+		std::string rightEyeSpaceName = "/me/viewpoint/right";
+		if (p.m_roomFromRightViewpointName.size() > 0) {
+			rightEyeSpaceName = p.m_roomFromRightViewpointName;
+		}
+
         m_displayWidth = m_params.m_displayConfiguration->getDisplayWidth();
         m_displayHeight = m_params.m_displayConfiguration->getDisplayHeight();
 
@@ -318,6 +330,18 @@ namespace renderkit {
             setDoingOkay(false);
         }
         osvrPose3SetIdentity(&m_roomFromHead);
+		if (osvrClientGetInterface(m_context, leftEyeSpaceName.c_str(),
+			&m_roomFromLeftViewpointInterface) ==
+			OSVR_RETURN_FAILURE) {
+			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << leftEyeSpaceName;
+		}
+		osvrPose3SetIdentity(&m_roomFromLeftViewpoint);
+		if (osvrClientGetInterface(m_context, rightEyeSpaceName.c_str(),
+			&m_roomFromRightViewpointInterface) ==
+			OSVR_RETURN_FAILURE) {
+			m_log->error() << "RenderManager::RenderManager(): Can't get interface " << rightEyeSpaceName;
+		}
+		osvrPose3SetIdentity(&m_roomFromRightViewpoint);
 
         // We haven't yet registered our render buffers, so can't present them
         m_renderBuffersRegistered = false;
@@ -1433,191 +1457,411 @@ namespace renderkit {
             return false;
         }
 
-        /// @todo Replace all of the quatlib math with Eigen math below,
-        /// or with direct calls to the core library.
+		// Check if there are poses available to use as viewpoints.
+		// If poses are available, render from each viewpoint.
+		// If not, the eyes are offset +- IPD from the head.
+		bool useViewpointPoses = hasLeftViewpointPose() && hasRightViewpointPose();
+		if (!useViewpointPoses)
+		{
 
-        /// We need to determine the transformation that takes points
-        /// in the space we're going to render in and moves them into
-        /// the space described by the projection matrix.  That space
-        /// is eye space, which has the eye at the origin, X to the
-        /// right, Y up, and Z pointing into the camera (opposite to
-        /// the viewing direction).
+			/// @todo Replace all of the quatlib math with Eigen math below,
+			/// or with direct calls to the core library.
 
-        /// Include the impact of rotating the screen around the
-        // eye location for HMDs who have this feature.  This is
-        // computed in terms of the percent overlap of the screen.
-        // We rotate each eye away from the other by half of the
-        // amount they should not overlap.  NOTE: This assumes
-        // that both eyes are at the same location w.r.t. the
-        // overlap percent.
-        // @todo Verify this assumption.
-        q_xyz_quat_type q_rotatedEyeFromEye;
-        makeIdentity(q_rotatedEyeFromEye);
-        double rotateEyesApart = 0;
-        double overlapFrac =
-            m_params.m_displayConfiguration->getOverlapPercent();
-        if (overlapFrac < 1.) {
-            const auto hfov =
-                m_params.m_displayConfiguration->getHorizontalFOV();
-            const auto angularOverlap = hfov * overlapFrac;
-            rotateEyesApart = util::getDegrees((hfov - angularOverlap) / 2.);
-        }
-        // Right eyes should rotate the other way.
-        if (whichEye % 2 != 0) {
-            rotateEyesApart *= -1;
-        }
-        rotateEyesApart = osvr::common::degreesToRadians(rotateEyesApart);
-        q_from_axis_angle(q_rotatedEyeFromEye.quat, 0, 1, 0, rotateEyesApart);
+			/// We need to determine the transformation that takes points
+			/// in the space we're going to render in and moves them into
+			/// the space described by the projection matrix.  That space
+			/// is eye space, which has the eye at the origin, X to the
+			/// right, Y up, and Z pointing into the camera (opposite to
+			/// the viewing direction).
 
-        /// Include the impact of the eyeFromHead matrix.
-        // This is a translation along the X axis in head space by
-        // the IPD, or its negation, depending on the eye.
-        // We assume that even eyes are left eyes and odd eyes are
-        // right eyes.  We further assume that head space is between
-        // the two eyes.  If the display descriptor wants us to swap
-        // eyes, we do so by inverting the offset for each eye.
-        /// @todo dealing with eye tracking here or mono displays
-        q_xyz_quat_type q_headFromRotatedEye;
-        makeIdentity(q_headFromRotatedEye);
-        if (whichEye % 2 == 0) {
-            // Left eye
-            q_headFromRotatedEye.xyz[Q_X] -= params.IPDMeters / 2;
-        } else {
-            // Right eye
-            q_headFromRotatedEye.xyz[Q_X] += params.IPDMeters / 2;
-        }
-        q_xyz_quat_type q_headFromEye;
-        q_xyz_quat_compose(&q_headFromEye, &q_headFromRotatedEye,
-                           &q_rotatedEyeFromEye);
+			/// Include the impact of rotating the screen around the
+			// eye location for HMDs who have this feature.  This is
+			// computed in terms of the percent overlap of the screen.
+			// We rotate each eye away from the other by half of the
+			// amount they should not overlap.  NOTE: This assumes
+			// that both eyes are at the same location w.r.t. the
+			// overlap percent.
+			// @todo Verify this assumption.
+			q_xyz_quat_type q_rotatedEyeFromEye;
+			makeIdentity(q_rotatedEyeFromEye);
+			double rotateEyesApart = 0;
+			double overlapFrac =
+				m_params.m_displayConfiguration->getOverlapPercent();
+			if (overlapFrac < 1.) {
+				const auto hfov =
+					m_params.m_displayConfiguration->getHorizontalFOV();
+				const auto angularOverlap = hfov * overlapFrac;
+				rotateEyesApart = util::getDegrees((hfov - angularOverlap) / 2.);
+			}
+			// Right eyes should rotate the other way.
+			if (whichEye % 2 != 0) {
+				rotateEyesApart *= -1;
+			}
+			rotateEyesApart = osvr::common::degreesToRadians(rotateEyesApart);
+			q_from_axis_angle(q_rotatedEyeFromEye.quat, 0, 1, 0, rotateEyesApart);
 
-        /// Include the impact of RenderParams.headFromRoom
-        /// (which will override m_headFromRoom) or of m_headFromRoom.
-        q_xyz_quat_type q_roomFromHead;
-        if (params.roomFromHeadReplace != nullptr) {
-            /// Use the params.m_headFromRoom as our transform
-            q_from_OSVR(q_roomFromHead, *params.roomFromHeadReplace);
-        } else {
-            /// Use the state interface to read the most-recent
-            /// location of the head.  It will have been updated
-            /// by the most-recent call to update() on the context.
-            /// DO NOT update the client here, so that we're using the
-            /// same state for all eyes.
-            OSVR_TimeValue timestamp;
-            if (!m_headPoseCache || !m_headPoseCache->getLastReport(timestamp, m_roomFromHead)) {
-                // This it not an error -- they may have put in an invalid
-                // state name for the head; we just ignore that case.
-            }
+			/// Include the impact of the eyeFromHead matrix.
+			// This is a translation along the X axis in head space by
+			// the IPD, or its negation, depending on the eye.
+			// We assume that even eyes are left eyes and odd eyes are
+			// right eyes.  We further assume that head space is between
+			// the two eyes.  If the display descriptor wants us to swap
+			// eyes, we do so by inverting the offset for each eye.
+			/// @todo dealing with eye tracking here or mono displays
+			q_xyz_quat_type q_headFromRotatedEye;
+			makeIdentity(q_headFromRotatedEye);
+			if (whichEye % 2 == 0) {
+				// Left eye
+				q_headFromRotatedEye.xyz[Q_X] -= params.IPDMeters / 2;
+			}
+			else {
+				// Right eye
+				q_headFromRotatedEye.xyz[Q_X] += params.IPDMeters / 2;
+			}
+			q_xyz_quat_type q_headFromEye;
+			q_xyz_quat_compose(&q_headFromEye, &q_headFromRotatedEye,
+				&q_rotatedEyeFromEye);
 
-            // Do prediction of where this eye will be when it is presented
-            // if client-side prediction is enabled.
-            if (m_params.m_clientPredictionEnabled) {
-              // Get information about how long we have until the next present.
-              // If we can't get timing info, we just set its offset to 0.
-              float msUntilPresent = 0;
-              OSVR_RenderTimingInfo timing;
-              if (GetTimingInfo(whichEye, timing)) {
-                msUntilPresent +=
-                  (timing.timeUntilNextPresentRequired.seconds * 1e3f) +
-                  (timing.timeUntilNextPresentRequired.microseconds / 1e3f);
-              }
+			/// Include the impact of RenderParams.headFromRoom
+			/// (which will override m_headFromRoom) or of m_headFromRoom.
+			q_xyz_quat_type q_roomFromHead;
+			if (params.roomFromHeadReplace != nullptr) {
+				/// Use the params.m_headFromRoom as our transform
+				q_from_OSVR(q_roomFromHead, *params.roomFromHeadReplace);
+			}
+			else {
+				/// Use the state interface to read the most-recent
+				/// location of the head.  It will have been updated
+				/// by the most-recent call to update() on the context.
+				/// DO NOT update the client here, so that we're using the
+				/// same state for all eyes.
+				OSVR_TimeValue timestamp;
+				if (!m_headPoseCache || !m_headPoseCache->getLastReport(timestamp, m_roomFromHead)) {
+					// This it not an error -- they may have put in an invalid
+					// state name for the head; we just ignore that case.
+				}
 
-              // Find out how long ago this tracker info was found.
-              float msSinceTrackerReport = 0;
-              {
-                  OSVR_TimeValue now;
-                  osvrTimeValueGetNow(&now);
-                  msSinceTrackerReport = static_cast<float>(osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3);
-              }
+				// Do prediction of where this eye will be when it is presented
+				// if client-side prediction is enabled.
+				if (m_params.m_clientPredictionEnabled) {
+					// Get information about how long we have until the next present.
+					// If we can't get timing info, we just set its offset to 0.
+					float msUntilPresent = 0;
+					OSVR_RenderTimingInfo timing;
+					if (GetTimingInfo(whichEye, timing)) {
+						msUntilPresent +=
+							(timing.timeUntilNextPresentRequired.seconds * 1e3f) +
+							(timing.timeUntilNextPresentRequired.microseconds / 1e3f);
+					}
 
-              // The delay before rendering for each
-              // eye will be different because they are at different delays past
-              // the next vsync.  The static delay common to both eyes has
-              // already been added into their offset.
-              float predictionIntervalms = msSinceTrackerReport +
-                msUntilPresent;
-              if (whichEye < m_params.m_eyeDelaysMS.size()) {
-                predictionIntervalms += m_params.m_eyeDelaysMS[whichEye];
-              }
-              float predictionIntervalSec = predictionIntervalms / 1e3f;
+					// Find out how long ago this tracker info was found.
+					float msSinceTrackerReport = 0;
+					{
+						OSVR_TimeValue now;
+						osvrTimeValueGetNow(&now);
+						msSinceTrackerReport = static_cast<float>(osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3);
+					}
 
-              // Find out the pose velocity information, if available.
-              // Set the valid flags to false so that if to call to get
-              // velocity fails, we will not try and use the info.
-              OSVR_VelocityState vel;
-              vel.linearVelocityValid = false;
-              vel.angularVelocityValid = false;
-              if (osvrGetVelocityState(m_roomFromHeadInterface, &timestamp, &vel) != OSVR_RETURN_SUCCESS) {
-                  // We're okay with failure here, we just use a zero
-                  // velocity to predict.
-                  // Using normal get state calls here because we're effectively
-                  // throwing away the returned timestamp for this data.
-              }
+					// The delay before rendering for each
+					// eye will be different because they are at different delays past
+					// the next vsync.  The static delay common to both eyes has
+					// already been added into their offset.
+					float predictionIntervalms = msSinceTrackerReport +
+						msUntilPresent;
+					if (whichEye < m_params.m_eyeDelaysMS.size()) {
+						predictionIntervalms += m_params.m_eyeDelaysMS[whichEye];
+					}
+					float predictionIntervalSec = predictionIntervalms / 1e3f;
 
-              // Predict the future pose of the head based on the velocity
-              // information and how long we should predict.  Check the
-              // linear and angular velocity terms to see if we should be
-              // using each.  Replace the pose with the predicted pose.
-              PredictFuturePose(m_roomFromHead, vel,
-                predictionIntervalSec, m_roomFromHead);
-            }
+					// Find out the pose velocity information, if available.
+					// Set the valid flags to false so that if to call to get
+					// velocity fails, we will not try and use the info.
+					OSVR_VelocityState vel;
+					vel.linearVelocityValid = false;
+					vel.angularVelocityValid = false;
+					if (osvrGetVelocityState(m_roomFromHeadInterface, &timestamp, &vel) != OSVR_RETURN_SUCCESS) {
+						// We're okay with failure here, we just use a zero
+						// velocity to predict.
+						// Using normal get state calls here because we're effectively
+						// throwing away the returned timestamp for this data.
+					}
 
-            // Bring the pose into quatlib world.
-            q_from_OSVR(q_roomFromHead, m_roomFromHead);
-        }
-        q_xyz_quat_type q_roomFromEye;
-        q_xyz_quat_compose(&q_roomFromEye, &q_roomFromHead, &q_headFromEye);
+					// Predict the future pose of the head based on the velocity
+					// information and how long we should predict.  Check the
+					// linear and angular velocity terms to see if we should be
+					// using each.  Replace the pose with the predicted pose.
+					PredictFuturePose(m_roomFromHead, vel,
+						predictionIntervalSec, m_roomFromHead);
+				}
 
-        // See if we are making a transform for world space.
-        // If don't have a callback defined for this space, we're in
-        // world space.  This is used by GetRenderInfo() and
-        // PresentRenderBuffers() to get its world-space matrix.
-        // If we have a NULL interface pointer, we are
-        // in world space.
-        bool inWorldSpace = (whichSpace >= m_callbacks.size()) ||
-                            (m_callbacks[whichSpace].m_interface == nullptr);
+				// Bring the pose into quatlib world.
+				q_from_OSVR(q_roomFromHead, m_roomFromHead);
+			}
+			q_xyz_quat_type q_roomFromEye;
+			q_xyz_quat_compose(&q_roomFromEye, &q_roomFromHead, &q_headFromEye);
 
-        /// Include the impact of roomFromWorld, if it is specified.
-        /// If we are not going into world space, but rather into one
-        /// of the other OSVR spaces, then just leave this as the identity
-        /// transform so we don't need to undo it again on the way
-        /// back from room space.
-        q_xyz_quat_type q_worldFromRoom;
-        makeIdentity(q_worldFromRoom);
-        if (inWorldSpace && (params.worldFromRoomAppend != nullptr)) {
-            q_from_OSVR(q_worldFromRoom, *params.worldFromRoomAppend);
-        }
-        q_xyz_quat_type q_worldFromEye;
-        q_xyz_quat_compose(&q_worldFromEye, &q_worldFromRoom, &q_roomFromEye);
+			// See if we are making a transform for world space.
+			// If don't have a callback defined for this space, we're in
+			// world space.  This is used by GetRenderInfo() and
+			// PresentRenderBuffers() to get its world-space matrix.
+			// If we have a NULL interface pointer, we are
+			// in world space.
+			bool inWorldSpace = (whichSpace >= m_callbacks.size()) ||
+				(m_callbacks[whichSpace].m_interface == nullptr);
 
-        /// Invert the above matrices, to produce eyeFromWorld.
-        q_xyz_quat_type q_eyeFromWorld;
-        q_xyz_quat_invert(&q_eyeFromWorld, &q_worldFromEye);
+			/// Include the impact of roomFromWorld, if it is specified.
+			/// If we are not going into world space, but rather into one
+			/// of the other OSVR spaces, then just leave this as the identity
+			/// transform so we don't need to undo it again on the way
+			/// back from room space.
+			q_xyz_quat_type q_worldFromRoom;
+			makeIdentity(q_worldFromRoom);
+			if (inWorldSpace && (params.worldFromRoomAppend != nullptr)) {
+				q_from_OSVR(q_worldFromRoom, *params.worldFromRoomAppend);
+			}
+			q_xyz_quat_type q_worldFromEye;
+			q_xyz_quat_compose(&q_worldFromEye, &q_worldFromRoom, &q_roomFromEye);
 
-        /// Include the impact of the space we're rendering to.
-        /// This is spaceFromRoom; put on the right and multiply it on
-        /// the left by the above inverted matrix.  (If we are going
-        /// into one of these spaces, worldFromRoom will be the
-        /// identity so we don't need to invert and reapply it.)
-        q_xyz_quat_type q_worldFromSpace;
-        if (inWorldSpace) {
-            makeIdentity(q_worldFromSpace);
-        } else {
-            OSVR_TimeValue timestamp;
-            if (osvrGetPoseState(
-                    m_callbacks[whichSpace].m_interface, &timestamp,
-                    &m_callbacks[whichSpace].m_state) == OSVR_RETURN_FAILURE) {
-                // They asked for a space that does not exist.  Return false to
-                // let them know we didn't get the one they wanted.
-                return false;
-            }
-            q_from_OSVR(q_worldFromSpace, m_callbacks[whichSpace].m_state);
-        }
-        q_xyz_quat_type q_eyeFromSpace;
-        q_xyz_quat_compose(&q_eyeFromSpace, &q_eyeFromWorld, &q_worldFromSpace);
+			/// Invert the above matrices, to produce eyeFromWorld.
+			q_xyz_quat_type q_eyeFromWorld;
+			q_xyz_quat_invert(&q_eyeFromWorld, &q_worldFromEye);
 
-        /// Store the result into the output pose
-        OSVR_from_q(eyeFromSpace, q_eyeFromSpace);
-        return true;
+			/// Include the impact of the space we're rendering to.
+			/// This is spaceFromRoom; put on the right and multiply it on
+			/// the left by the above inverted matrix.  (If we are going
+			/// into one of these spaces, worldFromRoom will be the
+			/// identity so we don't need to invert and reapply it.)
+			q_xyz_quat_type q_worldFromSpace;
+			if (inWorldSpace) {
+				makeIdentity(q_worldFromSpace);
+			}
+			else {
+				OSVR_TimeValue timestamp;
+				if (osvrGetPoseState(
+					m_callbacks[whichSpace].m_interface, &timestamp,
+					&m_callbacks[whichSpace].m_state) == OSVR_RETURN_FAILURE) {
+					// They asked for a space that does not exist.  Return false to
+					// let them know we didn't get the one they wanted.
+					return false;
+				}
+				q_from_OSVR(q_worldFromSpace, m_callbacks[whichSpace].m_state);
+			}
+			q_xyz_quat_type q_eyeFromSpace;
+			q_xyz_quat_compose(&q_eyeFromSpace, &q_eyeFromWorld, &q_worldFromSpace);
+
+			/// Store the result into the output pose
+			OSVR_from_q(eyeFromSpace, q_eyeFromSpace);
+			return true;
+		}
+		else //use left and right viewpoint poses instead of an offset from the head
+		{
+			q_xyz_quat_type q_roomFromEye;
+			if (whichEye % 2 == 0) { //left eye
+
+				if (params.roomFromLeftViewpointReplace != nullptr) {
+					q_from_OSVR(q_roomFromEye, *params.roomFromLeftViewpointReplace);
+				}
+				else
+				{
+					/// Use the state interface to read the most-recent
+					/// location of the left eye.  It will have been updated
+					/// by the most-recent call to update() on the context.
+					/// DO NOT update the client here, so that we're using the
+					/// same state for all eyes.
+					OSVR_TimeValue timestamp;
+					if (!m_leftViewpointPoseCache || !m_leftViewpointPoseCache->getLastReport(timestamp, m_roomFromLeftViewpoint)) {
+						// This it not an error -- they may have put in an invalid
+						// state name for the left eye; we just ignore that case.
+					}
+
+					// Do prediction of where this eye will be when it is presented
+					// if client-side prediction is enabled.
+					if (m_params.m_clientPredictionEnabled) {
+						// Get information about how long we have until the next present.
+						// If we can't get timing info, we just set its offset to 0.
+						float msUntilPresent = 0;
+						OSVR_RenderTimingInfo timing;
+						if (GetTimingInfo(whichEye, timing)) {
+							msUntilPresent +=
+								(timing.timeUntilNextPresentRequired.seconds * 1e3f) +
+								(timing.timeUntilNextPresentRequired.microseconds / 1e3f);
+						}
+
+						// Find out how long ago this tracker info was found.
+						float msSinceTrackerReport = 0;
+						{
+							OSVR_TimeValue now;
+							osvrTimeValueGetNow(&now);
+							msSinceTrackerReport = static_cast<float>(osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3);
+						}
+
+						// The delay before rendering for each
+						// eye will be different because they are at different delays past
+						// the next vsync.  The static delay common to both eyes has
+						// already been added into their offset.
+						float predictionIntervalms = msSinceTrackerReport +
+							msUntilPresent;
+						if (whichEye < m_params.m_eyeDelaysMS.size()) {
+							predictionIntervalms += m_params.m_eyeDelaysMS[whichEye];
+						}
+						float predictionIntervalSec = predictionIntervalms / 1e3f;
+
+						// Find out the pose velocity information, if available.
+						// Set the valid flags to false so that if to call to get
+						// velocity fails, we will not try and use the info.
+						OSVR_VelocityState vel;
+						vel.linearVelocityValid = false;
+						vel.angularVelocityValid = false;
+						if (osvrGetVelocityState(m_roomFromLeftViewpointInterface, &timestamp, &vel) != OSVR_RETURN_SUCCESS) {
+							// We're okay with failure here, we just use a zero
+							// velocity to predict.
+							// Using normal get state calls here because we're effectively
+							// throwing away the returned timestamp for this data.
+						}
+
+						// Predict the future pose of the head based on the velocity
+						// information and how long we should predict.  Check the
+						// linear and angular velocity terms to see if we should be
+						// using each.  Replace the pose with the predicted pose.
+						PredictFuturePose(m_roomFromLeftViewpoint, vel,
+							predictionIntervalSec, m_roomFromLeftViewpoint);
+					}
+
+					// Bring the pose into quatlib world.
+					q_from_OSVR(q_roomFromEye, m_roomFromLeftViewpoint);
+				}
+
+			}
+			else { //right eye
+				if (params.roomFromRightViewpointReplace != nullptr) {
+					/// Use the params.m_headFromRoom as our transform
+					q_from_OSVR(q_roomFromEye, *params.roomFromRightViewpointReplace);
+				}
+				else
+				{
+					/// Use the state interface to read the most-recent
+					/// location of the right eye.  It will have been updated
+					/// by the most-recent call to update() on the context.
+					/// DO NOT update the client here, so that we're using the
+					/// same state for all eyes.
+					OSVR_TimeValue timestamp;
+					if (!m_rightViewpointPoseCache || !m_rightViewpointPoseCache->getLastReport(timestamp, m_roomFromRightViewpoint)) {
+						// This it not an error -- they may have put in an invalid
+						// state name for the right eye; we just ignore that case.
+					}
+
+					// Do prediction of where this eye will be when it is presented
+					// if client-side prediction is enabled.
+					if (m_params.m_clientPredictionEnabled) {
+						// Get information about how long we have until the next present.
+						// If we can't get timing info, we just set its offset to 0.
+						float msUntilPresent = 0;
+						OSVR_RenderTimingInfo timing;
+						if (GetTimingInfo(whichEye, timing)) {
+							msUntilPresent +=
+								(timing.timeUntilNextPresentRequired.seconds * 1e3f) +
+								(timing.timeUntilNextPresentRequired.microseconds / 1e3f);
+						}
+
+						// Find out how long ago this tracker info was found.
+						float msSinceTrackerReport = 0;
+						{
+							OSVR_TimeValue now;
+							osvrTimeValueGetNow(&now);
+							msSinceTrackerReport = static_cast<float>(osvrTimeValueDurationSeconds(&now, &timestamp) * 1e3);
+						}
+
+						// The delay before rendering for each
+						// eye will be different because they are at different delays past
+						// the next vsync.  The static delay common to both eyes has
+						// already been added into their offset.
+						float predictionIntervalms = msSinceTrackerReport +
+							msUntilPresent;
+						if (whichEye < m_params.m_eyeDelaysMS.size()) {
+							predictionIntervalms += m_params.m_eyeDelaysMS[whichEye];
+						}
+						float predictionIntervalSec = predictionIntervalms / 1e3f;
+
+						// Find out the pose velocity information, if available.
+						// Set the valid flags to false so that if to call to get
+						// velocity fails, we will not try and use the info.
+						OSVR_VelocityState vel;
+						vel.linearVelocityValid = false;
+						vel.angularVelocityValid = false;
+						if (osvrGetVelocityState(m_roomFromRightViewpointInterface, &timestamp, &vel) != OSVR_RETURN_SUCCESS) {
+							// We're okay with failure here, we just use a zero
+							// velocity to predict.
+							// Using normal get state calls here because we're effectively
+							// throwing away the returned timestamp for this data.
+						}
+
+						// Predict the future pose of the head based on the velocity
+						// information and how long we should predict.  Check the
+						// linear and angular velocity terms to see if we should be
+						// using each.  Replace the pose with the predicted pose.
+						PredictFuturePose(m_roomFromRightViewpoint, vel,
+							predictionIntervalSec, m_roomFromRightViewpoint);
+					}
+
+					// Bring the pose into quatlib world.
+					q_from_OSVR(q_roomFromEye, m_roomFromRightViewpoint);
+				}
+
+			}
+
+			// See if we are making a transform for world space.
+			// If don't have a callback defined for this space, we're in
+			// world space.  This is used by GetRenderInfo() and
+			// PresentRenderBuffers() to get its world-space matrix.
+			// If we have a NULL interface pointer, we are
+			// in world space.
+			bool inWorldSpace = (whichSpace >= m_callbacks.size()) ||
+				(m_callbacks[whichSpace].m_interface == nullptr);
+
+			/// Include the impact of roomFromWorld, if it is specified.
+			/// If we are not going into world space, but rather into one
+			/// of the other OSVR spaces, then just leave this as the identity
+			/// transform so we don't need to undo it again on the way
+			/// back from room space.
+			q_xyz_quat_type q_worldFromRoom;
+			makeIdentity(q_worldFromRoom);
+			if (inWorldSpace && (params.worldFromRoomAppend != nullptr)) {
+				q_from_OSVR(q_worldFromRoom, *params.worldFromRoomAppend);
+			}
+			q_xyz_quat_type q_worldFromEye;
+			q_xyz_quat_compose(&q_worldFromEye, &q_worldFromRoom, &q_roomFromEye);
+
+			/// Invert the above matrices, to produce eyeFromWorld.
+			q_xyz_quat_type q_eyeFromWorld;
+			q_xyz_quat_invert(&q_eyeFromWorld, &q_worldFromEye);
+
+			/// Include the impact of the space we're rendering to.
+			/// This is spaceFromRoom; put on the right and multiply it on
+			/// the left by the above inverted matrix.  (If we are going
+			/// into one of these spaces, worldFromRoom will be the
+			/// identity so we don't need to invert and reapply it.)
+			q_xyz_quat_type q_worldFromSpace;
+			if (inWorldSpace) {
+				makeIdentity(q_worldFromSpace);
+			}
+			else {
+				OSVR_TimeValue timestamp;
+				if (osvrGetPoseState(
+					m_callbacks[whichSpace].m_interface, &timestamp,
+					&m_callbacks[whichSpace].m_state) == OSVR_RETURN_FAILURE) {
+					// They asked for a space that does not exist.  Return false to
+					// let them know we didn't get the one they wanted.
+					return false;
+				}
+				q_from_OSVR(q_worldFromSpace, m_callbacks[whichSpace].m_state);
+			}
+			q_xyz_quat_type q_eyeFromSpace;
+			q_xyz_quat_compose(&q_eyeFromSpace, &q_eyeFromWorld, &q_worldFromSpace);
+
+			/// Store the result into the output pose
+			OSVR_from_q(eyeFromSpace, q_eyeFromSpace);
+			return true;
+		}
     }
 
     bool RenderManager::ComputeAsynchronousTimeWarps(
@@ -1989,6 +2233,34 @@ namespace renderkit {
         }
         return m_headPoseCache->getLastReport(tv, pose);
     }
+
+	bool RenderManager::hasLeftViewpointPose() const {
+		if (!m_leftViewpointPoseCache) {
+			return false;
+		}
+		return m_leftViewpointPoseCache->hasReport();
+	}
+
+	bool RenderManager::hasRightViewpointPose() const {
+		if (!m_rightViewpointPoseCache) {
+			return false;
+		}
+		return m_rightViewpointPoseCache->hasReport();
+	}
+
+	bool RenderManager::getLastLeftViewpointPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const {
+		if (!m_leftViewpointPoseCache) {
+			return false;
+		}
+		return m_leftViewpointPoseCache->getLastReport(tv, pose);
+	}
+
+	bool RenderManager::getLastRightViewpointPose(OSVR_TimeValue& tv, OSVR_Pose3& pose) const {
+		if (!m_rightViewpointPoseCache) {
+			return false;
+		}
+		return m_rightViewpointPoseCache->getLastReport(tv, pose);
+	}
 
     static double pointDistance(double x1, double y1, double x2, double y2) {
         return std::sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));


### PR DESCRIPTION
If left and right viewpoint poses are present (we are getting reports from /me/viewpoints/left and /me/viewpoints/right), use them in ConstructModelView instead of head pose +- ipd

Continued from https://github.com/sensics/OSVR-RenderManager/pull/345