### PR TITLE
Fix multiple definition of function pointers in OpenGL ES (Android)

### DIFF
--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -47,6 +47,34 @@ Sensics, Inc.
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#ifdef OSVR_RM_USE_OPENGLES20
+  // Bind the extensions from the DLL
+  #include <dlfcn.h>
+  PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;
+  PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOES;
+  PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOES;
+  PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
+  class CalledBeforeCodeRuns {
+    public:
+      CalledBeforeCodeRuns() {
+	void *libhandle = dlopen("libGLESv2.so", RTLD_LAZY);
+
+	glBindVertexArrayOES = (PFNGLBINDVERTEXARRAYOESPROC)
+				dlsym(libhandle,
+				"glBindVertexArrayOES");
+	glDeleteVertexArraysOES = (PFNGLDELETEVERTEXARRAYSOESPROC)
+				dlsym(libhandle,
+				"glDeleteVertexArraysOES");
+	glGenVertexArraysOES = (PFNGLGENVERTEXARRAYSOESPROC)
+				dlsym(libhandle,
+				"glGenVertexArraysOES");
+	glDiscardFramebufferEXT = (PFNGLDISCARDFRAMEBUFFEREXTPROC)
+				dlsym(libhandle,
+				"glDiscardFramebufferEXT");
+    }
+  };
+  static CalledBeforeCodeRuns getFunctionPointers;
+#endif
 
 
 #ifndef OSVR_ANDROID
@@ -939,7 +967,7 @@ namespace renderkit {
     }
 
     RenderManagerOpenGL::DistortionMeshBuffer::DistortionMeshBuffer()
-        : 
+        :
         VAO(0),
         vertexBuffer(0),
         indexBuffer(0)

--- a/osvr/RenderKit/RenderManagerOpenGL.cpp
+++ b/osvr/RenderKit/RenderManagerOpenGL.cpp
@@ -1358,10 +1358,8 @@ namespace renderkit {
                     glDisable(GL_STENCIL_TEST);
                 }
             }
-            if (checkForGLError(
-                    "RenderManagerOpenGL::RenderEyeFinalize glBindFrameBuffer")) {
-                return false;
-            }
+            checkForGLError(
+                    "RenderManagerOpenGL::RenderEyeFinalize glBindFrameBuffer");
         });
 
         // Set up a Projection matrix that undoes the scale factor applied

--- a/osvr/RenderKit/RenderManagerOpenGL.h
+++ b/osvr/RenderKit/RenderManagerOpenGL.h
@@ -40,32 +40,11 @@ Sensics, Inc.
   #include <GLES2/gl2.h>
   #include <GLES2/gl2ext.h>
 
-  // Bind the extensions from the DLL
-  #include <dlfcn.h>
-  PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;
-  PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOES;
-  PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOES;
-  PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
-  class CalledBeforeCodeRuns {
-    public:
-      CalledBeforeCodeRuns() {
-	void *libhandle = dlopen("libGLESv2.so", RTLD_LAZY);
 
-	glBindVertexArrayOES = (PFNGLBINDVERTEXARRAYOESPROC)
-				dlsym(libhandle,
-				"glBindVertexArrayOES");
-	glDeleteVertexArraysOES = (PFNGLDELETEVERTEXARRAYSOESPROC)
-				dlsym(libhandle,
-				"glDeleteVertexArraysOES");
-	glGenVertexArraysOES = (PFNGLGENVERTEXARRAYSOESPROC)
-				dlsym(libhandle,
-				"glGenVertexArraysOES");
-	glDiscardFramebufferEXT = (PFNGLDISCARDFRAMEBUFFEREXTPROC)
-				dlsym(libhandle,
-				"glDiscardFramebufferEXT");
-    }
-  };
-  static CalledBeforeCodeRuns getFunctionPointers;
+  extern PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;
+  extern PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOES;
+  extern PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOES;
+  extern PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
 
 #else
   #ifdef __APPLE__
@@ -290,7 +269,7 @@ namespace renderkit {
         createRenderManager(OSVR_ClientContext context,
                             const std::string& renderLibraryName,
                             GraphicsLibrary graphicsLibrary);
-        
+
         friend class RenderManagerOpenGLATW;
     };
 


### PR DESCRIPTION
Not sure how this was building before on Android, but it didn't build with a newer NDK 16b-based setup (using clang and libc++).  Pretty clear duplicated definition, fairly straightforward resolution. File statics are guaranteed to be initialized by the time any code later in the file/TU is run, IIRC, so this should be the safe solution.