### PR TITLE
Remove incorrect and un-necessary flipping of Y center of projection …

### DIFF
--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -1952,7 +1952,7 @@ namespace renderkit {
               const float &xShearWithY = coeffs[2];
               const float &yShearWithX = coeffs[3];
               justInTimeWarp(0, 0) = xScale;
-              justInTimeWarp(1, 1) *= yScale; // Maintain sign, just scale
+              justInTimeWarp(1, 1) = yScale;
               justInTimeWarp(0, 1) = xShearWithY;
               justInTimeWarp(1, 0) = flipYScale * yShearWithX; // Shear in flipped direction
             }

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -2648,39 +2648,6 @@ namespace renderkit {
                 p2.m_renderLibrary = "Direct3D11";
                 p2.m_directMode = true;
 
-                // @todo This needs to be fixed elsewhere, and generalized to
-                // work with all forms of distortion correction.
-                // Flip y on the center of projection on the distortion
-                // correction, because we're going to be rendering in OpenGL
-                // but distorting in D3D, and they use a different texture
-                // orientation.
-                // When we do this, we need to take into account the D scaling
-                // factor being applied to the center of projection; first
-                // scaling back into unity, then flipping, then rescaling.
-                for (size_t eye = 0; eye < p.m_distortionParameters.size();
-                     ++eye) {
-                    if (p2.m_distortionParameters[eye].m_distortionCOP.size() <
-                        2) {
-                        m_log->error() << "Insufficient distortion parameters";
-                        return nullptr;
-                    }
-                    if (p2.m_distortionParameters[eye].m_distortionD.size() <
-                        2) {
-                        m_log->error() << "Insufficient distortion parameters";
-                        return nullptr;
-                    }
-                    float original =
-                        p2.m_distortionParameters[eye].m_distortionCOP[1];
-                    float normalized =
-                        original /
-                        p2.m_distortionParameters[eye].m_distortionD[1];
-                    float flipped = 1.0f - normalized;
-                    float scaled =
-                        flipped *
-                        p2.m_distortionParameters[eye].m_distortionD[1];
-                    p2.m_distortionParameters[eye].m_distortionCOP[1] = scaled;
-                }
-
                 // If we've been asked for asynchronous time warp, we layer
                 // the request on top of a request for a DirectRender instance
                 // to harness.  @todo This should be doable on top of a non-

--- a/osvr/RenderKit/RenderManagerBase.cpp
+++ b/osvr/RenderKit/RenderManagerBase.cpp
@@ -1952,14 +1952,9 @@ namespace renderkit {
               const float &xShearWithY = coeffs[2];
               const float &yShearWithX = coeffs[3];
               justInTimeWarp(0, 0) = xScale;
-              justInTimeWarp(1, 1) = yScale;
-              if (doTranspose) {
-                justInTimeWarp(0, 1) = xShearWithY;
-                justInTimeWarp(1, 0) = yShearWithX;
-              } else {
-                justInTimeWarp(1, 0) = xShearWithY;
-                justInTimeWarp(0, 1) = yShearWithX;
-              }
+              justInTimeWarp(1, 1) *= yScale; // Maintain sign, just scale
+              justInTimeWarp(0, 1) = xShearWithY;
+              justInTimeWarp(1, 0) = flipYScale * yShearWithX; // Shear in flipped direction
             }
 
             /// Scale the points so that they will fit into the range


### PR DESCRIPTION
…for distortion correction when harnessing an OpenGL renderer to a Direct3D DirectMode renderer.

This was scaling by the D factor, which it should not have been.  It also did not need to be done at all; apparently the buffer flipping elsewhere in the system takes care of this properly without requiring flipping of the COP here.

Validated this using OpenGL and OpenGL/Direct3D displays, one on the monitor and one on a DK2.